### PR TITLE
OP-5 split webrtccontext v2

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react';
 import { StatusBar } from 'expo-status-bar';
 import { useWebRTC } from '../../contexts/WebRTCContext';
 import { router, Link } from 'expo-router';
-import { Profile } from '../../types/profile'; // Ensure this matches your profile type
+import { Profile } from '../../types/types'; // Ensure this matches your profile type
 
 const MainScreen: React.FC = () => {
   const { profile, peers, disconnectFromWebSocket, peerIdRef } = useWebRTC();

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -37,7 +37,7 @@ export default function RootLayout() {
     return null;
   }
 
-  const iceServers = [
+  const iceServers: RTCIceServer[] = [
     { urls: "stun:stun.l.google.com:19302" },
     { urls: "stun:stun.l.google.com:5349" },
     { urls: "stun:stun1.l.google.com:3478" },
@@ -48,11 +48,11 @@ export default function RootLayout() {
     { urls: "stun:stun3.l.google.com:5349" },
     { urls: "stun:stun4.l.google.com:19302" },
     { urls: "stun:stun4.l.google.com:5349" },
-    { urls: TURN_SERVER_URL, username: "webrtc-react-native-demo", credential: TURN_PASSWORD }
+    { urls: TURN_SERVER_URL!, username: "webrtc-react-native-demo", credential: TURN_PASSWORD }
   ];
 
   return (
-    <WebRTCProvider signalingServerURL={signalingServerURL} token={TOKEN} iceServersList={iceServers}>
+    <WebRTCProvider signalingServerURL={signalingServerURL!} token={TOKEN!} iceServersList={iceServers}>
       <>
         {/* Define your stack navigator */}
         <KeyboardProvider>

--- a/app/chat/[peerId].tsx
+++ b/app/chat/[peerId].tsx
@@ -71,10 +71,6 @@ const ChatPage: React.FC = () => {
   }, [navigation, peerProfile]);
 
   useEffect(() => {
-    setupDatabase(peerIdString);
-  }, [peerId]);
-
-  useEffect(() => {
     loadMessages(peerIdString);
   }, [notifyChat]);
 

--- a/app/profile/index.tsx
+++ b/app/profile/index.tsx
@@ -4,7 +4,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as ImagePicker from "expo-image-picker";
 import { useRouter } from "expo-router";
 import crypto from "react-native-quick-crypto";
-import { Profile } from "../../types/profile";
+import { Profile } from "../../types/types";
 
 export default function ProfileScreen(): React.JSX.Element {
   const [name, setName] = useState<string>("");

--- a/contexts/WebRTCContext.tsx
+++ b/contexts/WebRTCContext.tsx
@@ -1,117 +1,23 @@
 import React, { createContext, useContext, useState, useRef, useEffect, ReactNode } from 'react';
 import {
   RTCPeerConnection,
-  RTCIceCandidate,
   RTCDataChannel,
   RTCDataChannelEvent,
   RTCIceCandidateEvent,
   MessageEvent,
-  Event,
-  RTCSessionDescription
+  Event
 } from 'react-native-webrtc';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { sendData } from './webrtcService';
-import { getSocket, disconnectSocket } from './socket';
+import { getSocket, disconnectSocket, handleWebSocketMessages } from './socket';
 import { Socket } from 'socket.io-client';
-import uuid from 'react-native-uuid';
 import { useRouter, Router } from 'expo-router';
-import crypto from 'react-native-quick-crypto';
-import { Buffer } from 'buffer';
-import { Profile } from '../types/profile'
-import { Message, saveMessageToDB } from '../app/chat/chatUtils';
-
-interface Peer {
-  id: string;
-  status: string;
-  profile?: Profile;
-}
-
-interface MessageData {
-  timestamp: number;
-  senderId: string;
-  message: string;
-  id: string;
-}
-
-type WebSocketMessageBase = {
-  from: string;
-  target: string | 'all';
-};
-
-type OfferMessage = WebSocketMessageBase & {
-  offer: RTCSessionDescription;
-};
-
-type AnswerMessage = WebSocketMessageBase & {
-  answer: RTCSessionDescription;
-};
-
-type CandidateMessage = WebSocketMessageBase & {
-  candidate: RTCIceCandidateInit;
-};
-
-type ConnectionsMessage = WebSocketMessageBase & {
-  payload: {
-    connections: { peerId: string }[];
-  };
-};
-
-type BroadcastMessage = WebSocketMessageBase & {
-  target: 'all';
-  payload: {
-    action: 'close';
-  };
-};
-
-type WebSocketMessage =
-  | OfferMessage
-  | AnswerMessage
-  | CandidateMessage
-  | ConnectionsMessage
-  | BroadcastMessage;
-
-type ReadyMessage = {
-  peerId: string;
-  type: string;
-};
-
-type PEXRequest = {
-  type: 'request';
-  maxNumberOfPeers: number;
-};
-
-type PEXAdvertisement = {
-  type: 'advertisement';
-  peers: string[];
-};
-
-type PEXMessage = PEXRequest | PEXAdvertisement;
-
-type ProfileMessage = {
-  type: 'profile';
-  profile: Profile;
-}
-
-interface WebRTCContextValue {
-  peers: Peer[];
-  setPeers: React.Dispatch<React.SetStateAction<Peer[]>>;
-  profile: Profile;
-  setProfile: React.Dispatch<React.SetStateAction<any>>;
-  peerIdRef: React.MutableRefObject<string | null>;
-  socket: Socket | null;
-  connections: { [key: string]: RTCPeerConnection };
-  chatDataChannels: Map<string, RTCDataChannel>;
-  createPeerConnection: (peerId: string, signalingDataChannel?: RTCDataChannel | null) => RTCPeerConnection;
-  updatePeerStatus: (peerId: string, status: string) => void;
-  updatePeerProfile: (peerId: string, profile: any) => void;
-  initiateConnection: (peerId: string, dataChannelUsedForSignaling?: RTCDataChannel | null) => Promise<void>;
-  handleOffer: (sdp: any, sender: string, channelUsedForSignaling?: RTCDataChannel | null) => Promise<void>;
-  sendMessageChatToPeer: (peerId: string, messageText: string, peerPublicKey: string) => void;
-  receiveMessageFromChat: (peerId: string, dataChannel: RTCDataChannel) => Promise<void>;
-  disconnectFromWebSocket: () => void;
-  chatMessagesRef: React.MutableRefObject<Map<string, MessageData[]>>;
-  notifyChat: number;
-}
+import { WebRTCContextValue, Peer, MessageData, Profile, ProfileMessage } from '../types/types';
+import { handleSignalingOverDataChannels } from './signaling';
+import { sendChatMessage, receiveMessageFromChat, initiateDBTable } from './chat';
+import { shareProfile, fetchProfile } from './profile';
+import { handlePEXMessages, sendPEXRequest } from './pex'
+import uuid from "react-native-uuid";
 
 const WebRTCContext = createContext<WebRTCContextValue | undefined>(undefined);
 
@@ -143,7 +49,8 @@ export const WebRTCProvider: React.FC<WebRTCProviderProps> = ({ children, signal
       const dataChannel: RTCDataChannel = event.channel;
       if (dataChannel.label === 'chat') {
         chatDataChannelsRef.current.set(peerId, dataChannel);
-        receiveMessageFromChat(peerId, dataChannel);
+        initiateDBTable(peerId, dataChannel);
+        receiveMessageFromChat(dataChannel, setNotifyChat);
       } else if (dataChannel.label === 'profile') {
         dataChannel.onopen = async () => {
           updatePeerStatus(peerId, 'open (answer side)');
@@ -195,7 +102,8 @@ export const WebRTCProvider: React.FC<WebRTCProviderProps> = ({ children, signal
 
         dataChannel.onmessage = (event: MessageEvent) => {
           console.log('Received pex message');
-          handlePEXMessages(event, dataChannel, signalingDataChannelsRef.current.get(peerId));
+          handlePEXMessages(event, dataChannel, connections, peerIdRef.current!,
+            initiateConnection, signalingDataChannelsRef.current.get(peerId)!);
         };
 
         const originalClose = dataChannel.close.bind(dataChannel);
@@ -213,7 +121,8 @@ export const WebRTCProvider: React.FC<WebRTCProviderProps> = ({ children, signal
 
         dataChannel.onmessage = async (event: MessageEvent) => {
           console.log('received message on signalingDataChannel - answer side' + event);
-          handleSignalingOverDataChannels(event, dataChannel);
+          handleSignalingOverDataChannels(event, peerIdRef.current!, connections, createPeerConnection,
+            setPeers, signalingDataChannelsRef.current, dataChannel);
         };
 
         const originalClose = dataChannel.close.bind(dataChannel);
@@ -265,7 +174,8 @@ export const WebRTCProvider: React.FC<WebRTCProviderProps> = ({ children, signal
 
     const chatDataChannel = peerConnection.createDataChannel('chat');
     chatDataChannelsRef.current.set(peerId, chatDataChannel);
-    receiveMessageFromChat(peerId, chatDataChannel);
+    initiateDBTable(peerId, chatDataChannel);
+    receiveMessageFromChat(chatDataChannel, setNotifyChat);
 
     const signalingDataChannel = peerConnection.createDataChannel('signaling');
     signalingDataChannel.onopen = () => {
@@ -273,7 +183,8 @@ export const WebRTCProvider: React.FC<WebRTCProviderProps> = ({ children, signal
     };
     signalingDataChannel.onmessage = async (event: MessageEvent) => {
       console.log('received message on signalingDataChannel - offer side' + event);
-      handleSignalingOverDataChannels(event, signalingDataChannel);
+      handleSignalingOverDataChannels(event, peerIdRef.current!, connections, createPeerConnection,
+        setPeers, signalingDataChannelsRef.current, signalingDataChannel);
     };
 
     const pexDataChannel = peerConnection.createDataChannel('pex');
@@ -282,7 +193,7 @@ export const WebRTCProvider: React.FC<WebRTCProviderProps> = ({ children, signal
       sendPEXRequest(pexDataChannel);
     };
     pexDataChannel.onmessage = async (event: MessageEvent) => {
-      handlePEXMessages(event, pexDataChannel, signalingDataChannelsRef.current.get(peerId));
+      handlePEXMessages(event, pexDataChannel, connections, peerIdRef.current!, initiateConnection, signalingDataChannelsRef.current.get(peerId)!);
     };
 
     const profileDataChannel = peerConnection.createDataChannel('profile');
@@ -325,220 +236,8 @@ export const WebRTCProvider: React.FC<WebRTCProviderProps> = ({ children, signal
     });
   };
 
-  const handleSignalingOverDataChannels = (event: MessageEvent, signalingDataChannel: RTCDataChannel): void => {
-    const message = JSON.parse(event.data) as WebSocketMessage;
-    if (message.target === peerIdRef.current) {
-      console.log('Signaling over datachannels reached its destination. Handling request: ' + JSON.stringify(message));
-      handleWebRTCSignaling(message, signalingDataChannel);
-    } else {
-      const targetPeer = Object.keys(connections).find((peerId) => peerId === message.target);
-      if (targetPeer) {
-        console.log('proxying signaling over dataChannels. Sending request to peer: ' + targetPeer);
-        const dataChannelToRecipientPeer = signalingDataChannelsRef.current.get(targetPeer);
-        if (dataChannelToRecipientPeer?.readyState === 'open') {
-          console.log('sending signaling over dataChannels to peer' + targetPeer);
-          dataChannelToRecipientPeer.send(JSON.stringify(message));
-        } else {
-          console.warn('Signaling DataChannel not open to peer: ' + targetPeer);
-        }
-      }
-    }
-  };
-
-  const handleWebRTCSignaling = (message: WebSocketMessage, dataChannelForSignaling: RTCDataChannel | null = null): void => {
-    if ('offer' in message) {
-      const offer = message.offer;
-      const from = message.from;
-      handleOffer(offer, from, dataChannelForSignaling);
-    } else if ('answer' in message) {
-      const from = message.from;
-      if (connections[from]) {
-        connections[from].setRemoteDescription(message.answer);
-      }
-    } else if ('candidate' in message) {
-      if (connections[message.from]) {
-        connections[message.from]
-          .addIceCandidate(new RTCIceCandidate(message.candidate))
-          .then(() => console.log('ICE candidate added successfully'))
-          .catch((e) => console.error('Error adding ICE candidate:', e));
-      }
-    }
-  };
-
-  const handleOffer = async (sdp: RTCSessionDescription, sender: string, channelUsedForSignaling: RTCDataChannel | null = null): Promise<void> => {
-    const peerConnection = createPeerConnection(sender, channelUsedForSignaling);
-    connections[sender] = peerConnection;
-    await peerConnection.setRemoteDescription(sdp);
-    const answer = await peerConnection.createAnswer();
-    await peerConnection.setLocalDescription(answer);
-
-    const answerMessage: AnswerMessage = {
-      target: sender,
-      from: peerIdRef.current!,
-      answer: answer,
-    };
-
-    if (channelUsedForSignaling == null) {
-      socket.current?.emit('messageOne', answerMessage);
-    } else {
-      console.log('Sending answer using signaling over datachannels to peer: ' + sender);
-      channelUsedForSignaling.send(JSON.stringify(answerMessage));
-    }
-
-    setPeers((prev) => {
-      if (prev.some((peer) => peer.id === sender)) {
-        return prev;
-      }
-      return [...prev, { id: sender, status: 'connecting' }];
-    });
-  };
-
-  const handlePEXMessages = (event: MessageEvent, pexDataChannel: RTCDataChannel, signalingDataChannel?: RTCDataChannel): void => {
-    try {
-      const message = JSON.parse(event.data) as PEXMessage;
-      if (message.type === 'request') {
-        shareConnectedPeers(pexDataChannel, message);
-      } else if (message.type === 'advertisement') {
-        const receivedPeers: string[] = message.peers;
-        const tableOfPeers: string[] = [];
-
-        if (Array.isArray(receivedPeers)) {
-          receivedPeers.forEach((peerId) => {
-            const alreadyConnected = Object.keys(connections).some((id) => id === peerId);
-            if (!tableOfPeers.includes(peerId) && !alreadyConnected && peerId !== peerIdRef.current) {
-              tableOfPeers.push(peerId);
-            }
-          });
-        }
-
-        tableOfPeers.forEach((peerId) => {
-          initiateConnection(peerId, signalingDataChannel);
-        });
-      }
-    } catch (error) {
-      console.error('Error handling PEX request:', error);
-    }
-  };
-
-  const sendPEXRequest = (pexDataChannel: RTCDataChannel): void => {
-    console.log('Sending PEX request');
-    const requestMessage: PEXRequest = {
-      type: 'request',
-      maxNumberOfPeers: 20,
-    };
-
-    try {
-      pexDataChannel.send(JSON.stringify(requestMessage));
-    } catch (error) {
-      console.log('Couldn’t send pex request: ' + error);
-    }
-  };
-
-  const shareConnectedPeers = (pexDataChannel: RTCDataChannel, message: PEXRequest): void => {
-    // TODO: read requested number of peers from PEXRequest
-    const peersToShare = new Set<string>();
-    if (Object.keys(connections).length !== 0) {
-      Object.keys(connections).forEach((peerId) => {
-        peersToShare.add(peerId);
-      });
-    }
-
-    const answer: PEXAdvertisement = {
-      type: 'advertisement',
-      peers: Array.from(peersToShare),
-    };
-    pexDataChannel.send(JSON.stringify(answer));
-  };
-
   const sendMessageChatToPeer = (peerId: string, messageText: string, peerPublicKey: string): void => {
-    const dataChannel = chatDataChannelsRef.current.get(peerId);
-  
-    if (!peerPublicKey) {
-      console.error(`❌ Nie można pobrać klucza publicznego.`);
-      return;
-    }
-    if (!peerIdRef.current) {
-      console.error('Cannot send message: peerIdRef.current is null');
-      return;
-    }
-
-    const messageData: Message = {
-      id: uuid.v4(),
-      timestamp: Date.now(),
-      senderId: peerIdRef.current ?? "",
-      destinationId: peerId,
-      message: messageText,
-    };
-  
-    if (dataChannel?.readyState === 'open') {
-      saveMessageToDB(messageData, messageData.destinationId); // Save the original unencrypted messageData to DB
-  
-      // Encrypt only the message field
-      const encryptedMessage = crypto.publicEncrypt(
-        peerPublicKey,
-        Buffer.from(messageData.message)
-      ).toString("base64");
-  
-      // Construct a new object with the encrypted message and unencrypted fields
-      const dataToSend = {
-        id: messageData.id,
-        timestamp: messageData.timestamp,
-        senderId: messageData.senderId,
-        destinationId: messageData.destinationId,
-        message: encryptedMessage, // Only the message is encrypted
-      };
-  
-      // Send the JSON stringified object
-      dataChannel.send(JSON.stringify(dataToSend));
-      console.log(`Message sent to peer ${peerId}:`, dataToSend);
-    } else {
-      console.log(`Data channel for peer ${peerId} is not ready`);
-    }
-  };
-
-  const receiveMessageFromChat = async (peerId: string, dataChannel: RTCDataChannel): Promise<void> => {
-
-    const privateKey = await AsyncStorage.getItem("privateKey");
-    if (!privateKey) {
-      console.error("❌ Brak prywatnego klucza. Nie można odszyfrować wiadomości.");
-      return;
-    }
-  
-    dataChannel.onmessage = async (event: MessageEvent) => {
-      try {
-        // Parse the received JSON data
-        const receivedData = JSON.parse(event.data);
-        console.log("Got raw received data:", receivedData);
-  
-        // Decrypt only the message field
-        const decryptedMessage = crypto.privateDecrypt(
-          privateKey,
-          Buffer.from(receivedData.message, "base64")
-        ).toString();
-  
-        // Construct the decrypted messageData with the original fields
-        const decryptedMessageData = {
-          id: receivedData.id,
-          timestamp: receivedData.timestamp,
-          senderId: receivedData.senderId,
-          destinationId: receivedData.destinationId,
-          message: decryptedMessage,
-        };
-  
-        console.log("Got decrypted messageData:", decryptedMessageData);
-  
-        saveMessageToDB(decryptedMessageData, decryptedMessageData.senderId);
-  
-        // Update chat messages in memory
-        const currentMessages = chatMessagesRef.current.get(peerId) || [];
-        const updatedMessages = [...currentMessages, decryptedMessageData];
-        chatMessagesRef.current.set(peerId, updatedMessages);
-  
-        setNotifyChat((prev) => prev + 1); // Trigger UI update
-      } catch (error) {
-        console.error("Error decrypting or processing message:", error);
-      }
-    };
+    sendChatMessage(peerId, peerIdRef.current!, messageText, peerPublicKey, chatDataChannelsRef.current);
   };
 
   const updatePeerStatus = (peerId: string, status: string): void => {
@@ -550,56 +249,19 @@ export const WebRTCProvider: React.FC<WebRTCProviderProps> = ({ children, signal
   };
 
   useEffect(() => {
-    // AsyncStorage.removeItem("userProfile");
-    const fetchProfile = async () => {
-      try {
-        const storedProfile = await AsyncStorage.getItem('userProfile');
-        if (storedProfile) {
-          const parsedProfile: Profile = JSON.parse(storedProfile);
-          setProfile(parsedProfile);
-        } else {
-          router.push('../profile');
-        }
-      } catch (error) {
-        console.error('Error fetching profile:', error);
-      }
-    };
-    fetchProfile();
+    fetchProfile(setProfile, router);
   }, []);
 
   useEffect(() => {
     socket.current = getSocket(signalingServerURL, token);
 
-    socket.current.on('message', (message: WebSocketMessage) => {
-      if (message.target === peerIdRef.current) {
-        if ('payload' in message && 'connections' in message.payload) {
-          const connectionsPayload: { peerId: string }[] = message.payload.connections;
-          connectionsPayload.forEach((peer) => {
-            const peerId = peer.peerId;
-            if (!connections[peerId]) {
-              initiateConnection(peerId);
-            }
-          });
-        } else {
-          handleWebRTCSignaling(message);
-        }
-      } else if (message.target === 'all') {
-        if ('payload' in message && 'action' in message.payload && message.payload.action === 'close') {
-          console.log(`Peer disconnected from signaling server: ${message.from}`);
-        }
-      }
-    });
-
-    socket.current.on('connect', () => {
-      console.log('Connected to signaling server. SocketId: ' + socket.current!.id);
+    if(!peerIdRef.current) {
       const generatedPeerId = uuid.v4() as string;
       peerIdRef.current = generatedPeerId;
-      const readyMessage: ReadyMessage = {
-        peerId: generatedPeerId,
-        type: 'type-emulator',
-      };
-      socket.current!.emit('ready', readyMessage.peerId, readyMessage.type);
-    });
+    }
+
+    handleWebSocketMessages(socket.current!, peerIdRef.current!, connections,
+      initiateConnection, createPeerConnection, setPeers);
 
     return () => {
       socket.current?.disconnect();
@@ -607,30 +269,12 @@ export const WebRTCProvider: React.FC<WebRTCProviderProps> = ({ children, signal
     };
   }, [signalingServerURL, token]);
 
-  async function shareProfile(sendFile: typeof sendData, dataChannel: RTCDataChannel): Promise<void> {
-    const storedProfile = await AsyncStorage.getItem('userProfile');
-    const profile = storedProfile ? JSON.parse(storedProfile) : null;
-    try {
-      if (profile !== null) {
-        console.log('Sending profile from offer side...');
-        sendFile(dataChannel, JSON.stringify({ type: 'profile', profile }));
-      }
-    } catch (error) {
-      console.error('Error while sending profile:', error);
-    }
-  }
-
   const disconnectFromWebSocket = (): void => {
     console.log('Disconnecting from signaling server. ' + socket.current?.id);
     disconnectSocket();
   };
 
   const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
-
-  // Only provide context when profile is loaded
-  if (!profile) {
-    return null;
-  }
 
   const value: WebRTCContextValue = {
     peers,
@@ -645,9 +289,7 @@ export const WebRTCProvider: React.FC<WebRTCProviderProps> = ({ children, signal
     updatePeerStatus,
     updatePeerProfile,
     initiateConnection,
-    handleOffer,
     sendMessageChatToPeer,
-    receiveMessageFromChat,
     disconnectFromWebSocket,
     chatMessagesRef,
     notifyChat

--- a/contexts/chat.ts
+++ b/contexts/chat.ts
@@ -1,0 +1,107 @@
+import { RTCDataChannel, MessageEvent } from "react-native-webrtc";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import uuid from "react-native-uuid";
+import crypto from "react-native-quick-crypto";
+import { Buffer } from "buffer";
+import { Message, saveMessageToDB, setupDatabase } from "../app/chat/chatUtils";
+
+export const sendChatMessage = (
+  targetPeerId: string,
+  senderPeerId: string,
+  messageText: string,
+  peerPublicKey: string,
+  chatDataChannels: Map<string, RTCDataChannel>
+): void => {
+  const dataChannel = chatDataChannels.get(targetPeerId);
+
+  if (!peerPublicKey) {
+    console.error(`Nie można pobrać klucza publicznego.`);
+    return;
+  }
+  if (!senderPeerId) {
+    console.error("Cannot send message: peerIdRef.current is null");
+    return;
+  }
+
+  const messageData: Message = {
+    id: uuid.v4(),
+    timestamp: Date.now(),
+    senderId: senderPeerId ?? "",
+    destinationId: targetPeerId,
+    message: messageText,
+  };
+
+  if (dataChannel?.readyState === "open") {
+    saveMessageToDB(messageData, messageData.destinationId); // Save the original unencrypted messageData to DB
+
+    // Encrypt only the message field
+    const encryptedMessage = crypto
+      .publicEncrypt(peerPublicKey, Buffer.from(messageData.message))
+      .toString("base64");
+
+    // Construct a new object with the encrypted message and unencrypted fields
+    const dataToSend = {
+      id: messageData.id,
+      timestamp: messageData.timestamp,
+      senderId: messageData.senderId,
+      destinationId: messageData.destinationId,
+      message: encryptedMessage, // Only the message is encrypted
+    };
+
+    // Send the JSON stringified object
+    dataChannel.send(JSON.stringify(dataToSend));
+    console.log(`Message sent to peer ${targetPeerId}:`, dataToSend);
+  } else {
+    console.log(`Data channel for peer ${targetPeerId} is not ready`);
+  }
+};
+
+export const receiveMessageFromChat = async (
+  dataChannel: RTCDataChannel,
+  setNotifyChat: React.Dispatch<React.SetStateAction<number>>
+): Promise<void> => {
+  const privateKey = await AsyncStorage.getItem("privateKey");
+  if (!privateKey) {
+    console.error("Brak prywatnego klucza. Nie można odszyfrować wiadomości.");
+    return;
+  }
+
+  dataChannel.onmessage = async (event: MessageEvent) => {
+    try {
+      // Parse the received JSON data
+      const receivedData = JSON.parse(event.data);
+      console.log("Got raw received data:", receivedData);
+
+      // Decrypt only the message field
+      const decryptedMessage = crypto
+        .privateDecrypt(privateKey, Buffer.from(receivedData.message, "base64"))
+        .toString();
+
+      // Construct the decrypted messageData with the original fields
+      const decryptedMessageData = {
+        id: receivedData.id,
+        timestamp: receivedData.timestamp,
+        senderId: receivedData.senderId,
+        destinationId: receivedData.destinationId,
+        message: decryptedMessage,
+      };
+
+      console.log("Got decrypted messageData:", decryptedMessageData);
+
+      saveMessageToDB(decryptedMessageData, decryptedMessageData.senderId);
+
+      setNotifyChat((prev) => prev + 1); // Trigger UI update
+    } catch (error) {
+      console.error("Error decrypting or processing message:", error);
+    }
+  };
+};
+
+export const initiateDBTable = async (
+  peerId: string,
+  dataChannel: RTCDataChannel
+) => {
+  dataChannel.onopen = () => {
+    setupDatabase(peerId);
+  };
+};

--- a/contexts/pex.ts
+++ b/contexts/pex.ts
@@ -1,0 +1,83 @@
+import {
+  RTCPeerConnection,
+  RTCDataChannel,
+  MessageEvent,
+} from "react-native-webrtc";
+import { PEXMessage, PEXRequest, PEXAdvertisement } from "../types/types";
+
+export const handlePEXMessages = (
+  event: MessageEvent,
+  pexDataChannel: RTCDataChannel,
+  connections: { [key: string]: RTCPeerConnection },
+  userPeerId: string,
+  initiateConnection: (
+    peerId: string,
+    dataChannelUsedForSignaling: RTCDataChannel | null
+  ) => Promise<void>,
+  signalingDataChannel: RTCDataChannel | null
+): void => {
+  try {
+    const message = JSON.parse(event.data) as PEXMessage;
+    if (message.type === "request") {
+      shareConnectedPeers(pexDataChannel, message, connections);
+    } else if (message.type === "advertisement") {
+      const receivedPeers: string[] = message.peers;
+      const tableOfPeers: string[] = [];
+
+      if (Array.isArray(receivedPeers)) {
+        receivedPeers.forEach((peerId) => {
+          const alreadyConnected = Object.keys(connections).some(
+            (id) => id === peerId
+          );
+          if (
+            !tableOfPeers.includes(peerId) &&
+            !alreadyConnected &&
+            peerId !== userPeerId
+          ) {
+            tableOfPeers.push(peerId);
+          }
+        });
+      }
+
+      tableOfPeers.forEach((peerId) => {
+        initiateConnection(peerId, signalingDataChannel);
+      });
+    }
+  } catch (error) {
+    console.error("Error handling PEX request:", error);
+  }
+};
+
+export const sendPEXRequest = (pexDataChannel: RTCDataChannel): void => {
+  console.log("Sending PEX request");
+  const requestMessage: PEXRequest = {
+    type: "request",
+    maxNumberOfPeers: 20,
+  };
+
+  try {
+    pexDataChannel.send(JSON.stringify(requestMessage));
+  } catch (error) {
+    console.log("Couldn’t send pex request: " + error);
+  }
+};
+
+const shareConnectedPeers = (
+  pexDataChannel: RTCDataChannel,
+  message: PEXRequest,
+  connections: { [key: string]: RTCPeerConnection }
+): void => {
+  // TODO: read requested number of peers from PEXRequest
+  const peersToShare = new Set<string>();
+  if (Object.keys(connections).length !== 0) {
+    Object.keys(connections).forEach((peerId) => {
+      peersToShare.add(peerId);
+    });
+  }
+
+  const answer: PEXAdvertisement = {
+    type: "advertisement",
+    peers: Array.from(peersToShare),
+  };
+  pexDataChannel.send(JSON.stringify(answer));
+};

--- a/contexts/profile.ts
+++ b/contexts/profile.ts
@@ -1,0 +1,42 @@
+import { RTCDataChannel } from "react-native-webrtc";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { sendData } from "./webrtcService";
+import { Router } from "expo-router";
+import { Profile } from "../types/types";
+
+export async function shareProfile(
+  sendFile: typeof sendData,
+  dataChannel: RTCDataChannel
+): Promise<void> {
+  const storedProfile = await AsyncStorage.getItem("userProfile");
+  const profile = storedProfile ? JSON.parse(storedProfile) : null;
+  try {
+    if (profile !== null) {
+      console.log("Sending profile from offer side...");
+      sendFile(dataChannel, JSON.stringify({ type: "profile", profile }));
+    }
+  } catch (error) {
+    console.error("Error while sending profile:", error);
+  }
+}
+
+export const fetchProfile = async (
+  setProfile: (profile: Profile | null) => void,
+  router: Router
+): Promise<void> => {
+  //   AsyncStorage.removeItem("userProfile");
+  try {
+    const storedProfile = await AsyncStorage.getItem("userProfile");
+    if (storedProfile) {
+      const parsedProfile: Profile = JSON.parse(storedProfile);
+      setProfile(parsedProfile);
+    } else {
+      setProfile(null);
+      router.replace("/profile"); // Absolute path to avoid relative routing issues
+    }
+  } catch (error) {
+    console.error("Error fetching profile:", error);
+    setProfile(null);
+    router.replace("/profile"); // Navigate on error as a fallback
+  }
+};

--- a/contexts/signaling.ts
+++ b/contexts/signaling.ts
@@ -1,0 +1,134 @@
+import {
+  RTCPeerConnection,
+  RTCIceCandidate,
+  RTCSessionDescription,
+  RTCDataChannel,
+  MessageEvent,
+} from "react-native-webrtc";
+import { Socket } from "socket.io-client";
+import { WebSocketMessage, Peer } from "../types/types";
+
+export const handleOffer = async (
+  sdp: RTCSessionDescription,
+  sender: string,
+  target: string,
+  createPeerConnection: (
+    peerId: string,
+    channel?: RTCDataChannel | null
+  ) => RTCPeerConnection,
+  connections: { [key: string]: RTCPeerConnection },
+  socket: Socket | null,
+  setPeers: React.Dispatch<React.SetStateAction<Peer[]>>,
+  signalingChannel?: RTCDataChannel | null
+) => {
+  const peerConnection = createPeerConnection(sender, signalingChannel);
+  connections[sender] = peerConnection;
+  await peerConnection.setRemoteDescription(sdp);
+  const answer = await peerConnection.createAnswer();
+  await peerConnection.setLocalDescription(answer);
+
+  const answerMessage = { target: sender, from: target, answer };
+  if (signalingChannel) {
+    signalingChannel.send(JSON.stringify(answerMessage));
+  } else {
+    console.log(
+      `Sending answer via WebSocket to ${sender}. Socket connected: ${
+        socket?.connected || false
+      }`
+    );
+    socket?.emit("messageOne", answerMessage);
+  }
+
+  setPeers((prev) => {
+    if (prev.some((peer) => peer.id === sender)) {
+      return prev;
+    }
+    return [...prev, { id: sender, status: "connecting" }];
+  });
+};
+
+export const handleWebRTCSignaling = (
+  message: WebSocketMessage,
+  connections: { [key: string]: RTCPeerConnection },
+  createPeerConnection: (
+    peerId: string,
+    channel?: RTCDataChannel | null
+  ) => RTCPeerConnection,
+  setPeers: React.Dispatch<React.SetStateAction<Peer[]>>,
+  socket: Socket | null,
+  signalingChannel?: RTCDataChannel | null
+) => {
+  if ("offer" in message) {
+    console.log("Handling offer");
+    console.log(`Websocket: ${socket?.connected || false}`);
+    handleOffer(
+      message.offer,
+      message.from,
+      message.target,
+      createPeerConnection,
+      connections,
+      socket,
+      setPeers,
+      signalingChannel
+    );
+  } else if ("answer" in message) {
+    console.log("Handling answer");
+    const from = message.from;
+    if (connections[from]) {
+      connections[from].setRemoteDescription(message.answer);
+    }
+  } else if ("candidate" in message) {
+    if (connections[message.from]) {
+      connections[message.from]
+        .addIceCandidate(new RTCIceCandidate(message.candidate))
+        .then(() => console.log("ICE candidate added successfully"))
+        .catch((e) => console.error("Error adding ICE candidate:", e));
+    }
+  }
+};
+
+export const handleSignalingOverDataChannels = (
+  event: MessageEvent,
+  peerId: string,
+  connections: { [key: string]: RTCPeerConnection },
+  createPeerConnection: (
+    peerId: string,
+    channel?: RTCDataChannel | null
+  ) => RTCPeerConnection,
+  setPeers: React.Dispatch<React.SetStateAction<Peer[]>>,
+  signalingDataChannels: Map<string, RTCDataChannel>,
+  signalingDataChannel: RTCDataChannel
+): void => {
+  const message = JSON.parse(event.data) as WebSocketMessage;
+  if (message.target === peerId) {
+    console.log(
+      "Signaling over datachannels reached its destination. Handling request: " +
+        JSON.stringify(message)
+    );
+    handleWebRTCSignaling(
+      message,
+      connections,
+      createPeerConnection,
+      setPeers,
+      null,
+      signalingDataChannel
+    );
+  } else {
+    const targetPeer = Object.keys(connections).find(
+      (peerId) => peerId === message.target
+    );
+    if (targetPeer) {
+      console.log(
+        "proxying signaling over dataChannels. Sending request to peer: " +
+          targetPeer
+      );
+      const dataChannelToRecipientPeer = signalingDataChannels.get(targetPeer);
+      if (dataChannelToRecipientPeer?.readyState === "open") {
+        console.log("sending signaling over dataChannels to peer" + targetPeer);
+        dataChannelToRecipientPeer.send(JSON.stringify(message));
+      } else {
+        console.warn("Signaling DataChannel not open to peer: " + targetPeer);
+      }
+    }
+  }
+};

--- a/contexts/socket.ts
+++ b/contexts/socket.ts
@@ -1,14 +1,74 @@
-import { io, Socket } from 'socket.io-client';
+import { io, Socket } from "socket.io-client";
+import { handleWebRTCSignaling } from "./signaling";
+import { Peer, WebSocketMessage, ReadyMessage } from "../types/types";
+import { RTCPeerConnection, RTCDataChannel } from "react-native-webrtc";
 
 let socket: Socket | null = null;
 
-export const getSocket = (signalingServerURL: string, token: string): Socket => {
+export const getSocket = (
+  signalingServerURL: string,
+  token: string
+): Socket => {
   if (!socket) {
     socket = io(signalingServerURL, {
       auth: { token },
     });
   }
   return socket;
+};
+
+export const handleWebSocketMessages = (
+  socketRef: Socket,
+  userPeerId: string,
+  connections: { [key: string]: RTCPeerConnection },
+  initiateConnection: (
+    peerId: string,
+    dataChannelUsedForSignaling?: RTCDataChannel | null
+  ) => Promise<void>,
+  createPeerConnection: (
+    peerId: string,
+    signalingDataChannel?: RTCDataChannel | null
+  ) => RTCPeerConnection,
+  setPeers: React.Dispatch<React.SetStateAction<Peer[]>>
+): void => {
+  socketRef.on("message", (message: WebSocketMessage) => {
+    if (message.target === userPeerId) {
+      if ("payload" in message && "connections" in message.payload) {
+        const connectionsPayload: { peerId: string }[] =
+          message.payload.connections;
+        connectionsPayload.forEach((peer) => {
+          const peerId = peer.peerId;
+          if (!connections[peerId]) {
+            initiateConnection(peerId);
+          }
+        });
+      } else {
+        handleWebRTCSignaling(
+          message,
+          connections,
+          createPeerConnection,
+          setPeers,
+          socketRef
+        );
+      }
+    } else if (message.target === "all") {
+      if (
+        "payload" in message &&
+        "action" in message.payload &&
+        message.payload.action === "close"
+      ) {
+        console.log(`Peer disconnected from signaling server: ${message.from}`);
+      }
+    }
+  });
+
+  socketRef.on("connect", () => {
+    const readyMessage: ReadyMessage = {
+      peerId: userPeerId,
+      type: "type-emulator",
+    };
+    socketRef.emit("ready", readyMessage.peerId, readyMessage.type);
+  });
 };
 
 export const disconnectSocket = (): void => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "react-native-sqlite-storage": "^6.0.1",
         "react-native-uuid": "^2.0.3",
         "react-native-web": "~0.19.13",
-        "react-native-webrtc": "^124.0.4",
+        "react-native-webrtc": "^124.0.5",
         "react-native-webview": "13.12.5",
         "socket.io-client": "^4.8.1",
         "undici": "^7.1.1"
@@ -12987,9 +12987,9 @@
       "license": "MIT"
     },
     "node_modules/react-native-webrtc": {
-      "version": "124.0.4",
-      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-124.0.4.tgz",
-      "integrity": "sha512-ZbhSz1f+kc1v5VE0B84+v6ujIWTHa2fIuocrYzGUIFab7E5izmct7PNHb9dzzs0xhBGqh4c2rUa49jbL+P/e2w==",
+      "version": "124.0.5",
+      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-124.0.5.tgz",
+      "integrity": "sha512-LIQJKst+t53bJOcQef9VXuz3pVheSBUA4olQGkxosbF4pHW1gsWoXYmf6wmI2zrqOA+aZsjjB6aT9AKLyr6a0Q==",
       "license": "MIT",
       "dependencies": {
         "base64-js": "1.5.1",

--- a/types/profile.ts
+++ b/types/profile.ts
@@ -1,6 +1,0 @@
-export interface Profile {
-  name: string;
-  profilePic: string;
-  publicKey: string;
-  additionalPics?: string[];
-}

--- a/types/types.ts
+++ b/types/types.ts
@@ -1,0 +1,114 @@
+import { Socket } from "socket.io-client";
+import {
+  RTCPeerConnection,
+  RTCDataChannel,
+  RTCSessionDescription,
+} from "react-native-webrtc";
+
+export interface Profile {
+  name: string;
+  profilePic: string;
+  publicKey: string;
+  additionalPics?: string[];
+}
+
+export interface Peer {
+  id: string;
+  status: string;
+  profile?: Profile;
+}
+
+export interface MessageData {
+  timestamp: number;
+  senderId: string;
+  message: string;
+  id: string;
+}
+
+export type WebSocketMessageBase = {
+  from: string;
+  target: string | "all";
+};
+
+export type OfferMessage = WebSocketMessageBase & {
+  offer: RTCSessionDescription;
+};
+
+export type AnswerMessage = WebSocketMessageBase & {
+  answer: RTCSessionDescription;
+};
+
+export type CandidateMessage = WebSocketMessageBase & {
+  candidate: RTCIceCandidateInit;
+};
+
+export type ConnectionsMessage = WebSocketMessageBase & {
+  payload: {
+    connections: { peerId: string }[];
+  };
+};
+
+export type BroadcastMessage = WebSocketMessageBase & {
+  target: "all";
+  payload: {
+    action: "close";
+  };
+};
+
+export type WebSocketMessage =
+  | OfferMessage
+  | AnswerMessage
+  | CandidateMessage
+  | ConnectionsMessage
+  | BroadcastMessage;
+
+export type ReadyMessage = {
+  peerId: string;
+  type: string;
+};
+
+export type PEXRequest = {
+  type: "request";
+  maxNumberOfPeers: number;
+};
+
+export type PEXAdvertisement = {
+  type: "advertisement";
+  peers: string[];
+};
+
+export type PEXMessage = PEXRequest | PEXAdvertisement;
+
+export type ProfileMessage = {
+  type: "profile";
+  profile: Profile;
+};
+
+export interface WebRTCContextValue {
+  peers: Peer[];
+  setPeers: React.Dispatch<React.SetStateAction<Peer[]>>;
+  profile: Profile | null;
+  setProfile: React.Dispatch<React.SetStateAction<any>>;
+  peerIdRef: React.MutableRefObject<string | null>;
+  socket: Socket | null;
+  connections: { [key: string]: RTCPeerConnection };
+  chatDataChannels: Map<string, RTCDataChannel>;
+  createPeerConnection: (
+    peerId: string,
+    signalingDataChannel?: RTCDataChannel | null
+  ) => RTCPeerConnection;
+  updatePeerStatus: (peerId: string, status: string) => void;
+  updatePeerProfile: (peerId: string, profile: any) => void;
+  initiateConnection: (
+    peerId: string,
+    dataChannelUsedForSignaling?: RTCDataChannel | null
+  ) => Promise<void>;
+  sendMessageChatToPeer: (
+    peerId: string,
+    message: string,
+    peerPublicKey: string
+  ) => void;
+  disconnectFromWebSocket: () => void;
+  chatMessagesRef: React.MutableRefObject<Map<string, MessageData[]>>;
+  notifyChat: number;
+}


### PR DESCRIPTION
## Split Functionality: Refactored WebRTCContext.tsx into separate files: chat.ts, pex.ts, profile.ts, signaling.ts, and socket.ts.
- Chat Logic: Moved chat message handling to chat.ts (sendChatMessage, receiveMessageFromChat, initiateDBTable).
- PEX Logic: Extracted peer exchange to pex.ts (sendPEXRequest, handlePEXMessages).
- Profile Logic: Separated profile fetching/sharing to profile.ts (fetchProfile, shareProfile).
- Signaling Logic: Moved signaling to signaling.ts (handleSignalingOverDataChannels).
- Socket Management: Relocated WebSocket logic to socket.ts (getSocket, disconnectSocket, handleWebSocketMessages).
## WebRTCContext.tsx 
- Imported functions from new 
- Simplified sendMessageChatToPeer to use 
- Added uuid for peerIdRef.current initialization before socket setup.

## Bug Fixes:
- `initiateDBTable()` is called as soon as the chat datachannel is opened, ensuring that the incoming messages will have dedicated table created where they can be saved. It covers the case when messages are send before the other peer have opened the chat on UI.