### PR TITLE
noissue: fix ice candidates queue

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -18,6 +18,7 @@ type RootStackParamList = {
 };
 
 export default function RootLayout() {
+  // const signalingServerURL = "http://10.0.2.2:3030";
   const signalingServerURL = process.env.EXPO_PUBLIC_SIGNALING_SERVER_URL;
   const TOKEN = process.env.EXPO_PUBLIC_SIGNALING_SERVER_TOKEN;
   const TURN_PASSWORD = process.env.EXPO_PUBLIC_TURN_PASSWORD;

--- a/contexts/dht/cache-strategy.ts
+++ b/contexts/dht/cache-strategy.ts
@@ -78,7 +78,7 @@ export class DistanceBasedCacheStrategy extends EventEmitter implements CacheStr
     sendMessage: (node: Node, sender: string, recipient: string, message: MessageDTO) => Promise<boolean>,
     maxTTL: number
   ): Promise<void> {
-    console.log("Trying to deliver cached messages (LRU)");
+    // console.log("Trying to deliver cached messages (LRU)");
     const now = Date.now();
     for (const [messageId, msg] of this.cachedMessages) {
       if (now - msg.message.timestamp > maxTTL) {

--- a/contexts/dht/dht.ts
+++ b/contexts/dht/dht.ts
@@ -262,7 +262,7 @@ class DHT extends EventEmitter {
         (node: Node, sender: string, recipient: string, message: MessageDTO) => this.rpc.sendMessage(node, sender, recipient, message),
         this.MAX_TTL
       ).then(() => {
-        console.log(`Cleaned up expired messages; ${this.cacheStrategy.getCachedMessageCount()} remain`);
+        // console.log(`Cleaned up expired messages; ${this.cacheStrategy.getCachedMessageCount()} remain`);
       });
     }, 5 * 60 * 1000);
   }


### PR DESCRIPTION
## Changelog

### Added Periodic Cleanup for Stale Connecting Peers
Introduced a periodic worker that monitors peers in the connecting state. Peers remaining in this state for over 10 seconds are removed from the connections map, and their associated RTCPeerConnection and data channels are closed. This ensures timely cleanup of stalled connection attempts, improving resource management and connection reliability.
### Limited ICE Candidate Queue Lifetime
Configured ICE candidates stored in the queue to expire after 5 seconds. This prevents accumulation of outdated candidates, reducing memory usage and ensuring only relevant candidates are processed during connection establishment.
### Queued ICE Candidates for Connected Peers
Updated handling of ICE candidates received for peers in the connected state. Such candidates are now added to the queue, potentially triggering an ICE restart to re-establish the connection. This enhances robustness by accommodating network changes or reconnections without disrupting existing sessions.
### Replaced Existing Connection on New Offer
Implemented logic to close and replace an existing RTCPeerConnection when a new offer is received from an already connected peer. The old connection is terminated, its resources are cleaned up, and a new connection is initiated. This ensures seamless reconnection when a peer restarts, preventing conflicts with stale connections.

## Notes

These changes improve the stability and efficiency of WebRTC connection management by addressing stale connections, optimizing ICE candidate handling, and supporting robust reconnection scenarios. They are particularly effective in handling cases where peers close and reopen the app, ensuring consistent connectivity and resource cleanup.