### PR TITLE
OP-34: Add rejoining the network logic

### DIFF
--- a/contexts/connection-manger.ts
+++ b/contexts/connection-manger.ts
@@ -1,0 +1,71 @@
+import { RTCDataChannel, RTCPeerConnection } from "react-native-webrtc";
+import { sendPEXRequest } from "./pex";
+
+export class ConnectionManager {
+  private minPeers: number = 20;
+  private checkInterval: number = 20 * 1000; // 20s
+  private connectionsRef: Map<string, RTCPeerConnection>;
+  private pexDataChannelsRef: Map<string, RTCDataChannel>;
+  private intervalId: NodeJS.Timeout | null = null;
+
+  constructor(
+    connectionsRef: Map<string, RTCPeerConnection>,
+    pexDataChannelsRef: Map<string, RTCDataChannel>
+  ) {
+    this.connectionsRef = connectionsRef;
+    this.pexDataChannelsRef = pexDataChannelsRef;
+  }
+
+  public start(): void {
+    if (this.intervalId) {
+      console.warn("ConnectionManager is already running");
+      return;
+    }
+
+    this.checkPeerConnections();
+    this.intervalId = setInterval(() => {
+      this.checkPeerConnections();
+    }, this.checkInterval);
+    console.log("ConnectionManager started");
+  }
+
+  public stop(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+      console.log("ConnectionManager stopped");
+    }
+  }
+
+  private getRandomOpenDataChannel(): RTCDataChannel | null {
+    const openChannels = Array.from(this.pexDataChannelsRef.values()).filter(
+      (channel) => channel.readyState === "open"
+    );
+    if (openChannels.length === 0) {
+      return null;
+    }
+    const randomIndex = Math.floor(Math.random() * openChannels.length);
+    return openChannels[randomIndex];
+  }
+
+  private checkPeerConnections(): void {
+    const currentPeerCount = this.connectionsRef.size;
+    console.log(`Current peer count: ${currentPeerCount}`);
+
+    if (currentPeerCount < this.minPeers) {
+      const peersNeeded = this.minPeers - currentPeerCount;
+      const dataChannel = this.getRandomOpenDataChannel();
+
+      if (dataChannel) {
+        console.log(`Requesting ${peersNeeded} additional peers via PEX`);
+        try {
+          sendPEXRequest(dataChannel, peersNeeded);
+        } catch (error) {
+          console.error("Failed to send PEX request:", error);
+        }
+      } else {
+        console.warn("No open PEX data channels available to send request");
+      }
+    }
+  }
+}

--- a/contexts/connection-manger.ts
+++ b/contexts/connection-manger.ts
@@ -1,19 +1,29 @@
 import { RTCDataChannel, RTCPeerConnection } from "react-native-webrtc";
 import { sendPEXRequest } from "./pex";
+import DHT from "./dht/dht";
+import { PeerDTO } from "../types/types";
+import { Node } from "./dht/webrtc-rpc";
+import { fetchUserFromDB } from "./db/userdb";
 
 export class ConnectionManager {
   private minPeers: number = 20;
   private checkInterval: number = 20 * 1000; // 20s
   private connectionsRef: Map<string, RTCPeerConnection>;
   private pexDataChannelsRef: Map<string, RTCDataChannel>;
+  private dhtRef: DHT;
+  private initiateConnection: (targetPeer: PeerDTO, dataChannelUsedForSignaling: RTCDataChannel | null, useDHTForSignaling: boolean) => Promise<void>;
   private intervalId: NodeJS.Timeout | null = null;
 
   constructor(
     connectionsRef: Map<string, RTCPeerConnection>,
-    pexDataChannelsRef: Map<string, RTCDataChannel>
+    pexDataChannelsRef: Map<string, RTCDataChannel>,
+    dhtRef: DHT,
+    initiateConnection: (targetPeer: PeerDTO, dataChannelUsedForSignaling?: RTCDataChannel | null) => Promise<void>
   ) {
     this.connectionsRef = connectionsRef;
     this.pexDataChannelsRef = pexDataChannelsRef;
+    this.dhtRef = dhtRef;
+    this.initiateConnection = initiateConnection;
   }
 
   public start(): void {
@@ -48,24 +58,86 @@ export class ConnectionManager {
     return openChannels[randomIndex];
   }
 
-  private checkPeerConnections(): void {
+  private async checkPeerConnections(): Promise<void> {
     const currentPeerCount = this.connectionsRef.size;
     console.log(`Current peer count: ${currentPeerCount}`);
 
-    if (currentPeerCount < this.minPeers) {
-      const peersNeeded = this.minPeers - currentPeerCount;
-      const dataChannel = this.getRandomOpenDataChannel();
+    if (currentPeerCount >= this.minPeers) {
+      console.log(`Minimum peer count (${this.minPeers}) already satisfied`);
+      return;
+    }
 
-      if (dataChannel) {
-        console.log(`Requesting ${peersNeeded} additional peers via PEX`);
-        try {
-          sendPEXRequest(dataChannel, peersNeeded);
-        } catch (error) {
-          console.error("Failed to send PEX request:", error);
+    const peersNeeded = this.minPeers - currentPeerCount;
+    console.log(`Need ${peersNeeded} additional peers`);
+
+    const availablePeers: Node[] = [];
+    // Access the buckets directly (Node[][])
+    try {
+      const nodesInBuckets = this.dhtRef.getBuckets().all() as Node[];
+      const nodeId = this.dhtRef.getNodeId();
+
+      // Collect available peers from buckets, starting from bucket 0 (closest)
+      
+      for (const peer of nodesInBuckets) {
+        if (peer.id !== nodeId && !this.connectionsRef.has(peer.id)) {
+          availablePeers.push(peer);
         }
-      } else {
-        console.warn("No open PEX data channels available to send request");
       }
+
+      if (availablePeers.length === 0) {
+        console.warn("No available peers in k-buckets; falling back to PEX");
+        this.requestPeersViaPEX(peersNeeded);
+        return;
+      }
+    } catch(err) {
+      console.log(err)
+    }
+    
+
+    console.log(`Found ${availablePeers.length} available peers in k-buckets`);
+
+    // Attempt to connect to up to peersNeeded peers
+    let peersAttempted = 0;
+    for (const peer of availablePeers) {
+      if (peersAttempted >= peersNeeded) {
+        break;
+      }
+
+      const peerDTO: PeerDTO = {
+        peerId: peer.id,
+        publicKey: (await fetchUserFromDB(peer.id))?.publicKey!
+      };
+
+      console.log(`Attempting connection to peer ${peer.id}`);
+      try {
+        await this.initiateConnection(peerDTO, null, true); // Use DHT for signaling
+        peersAttempted++;
+      } catch (error) {
+        console.error(`Failed to initiate connection to peer ${peer.id}:`, error);
+        // Continue to the next peer
+      }
+    }
+
+    console.log(`Attempted connections to ${peersAttempted} peers`);
+
+    // If we couldn't attempt enough connections, fall back to PEX
+    if (peersAttempted < peersNeeded) {
+      console.log(`Could only attempt ${peersAttempted} of ${peersNeeded} needed peers; requesting via PEX`);
+      // this.requestPeersViaPEX(peersNeeded - peersAttempted);
+    }
+  }
+
+  private requestPeersViaPEX(peersNeeded: number): void {
+    const dataChannel = this.getRandomOpenDataChannel();
+    if (dataChannel) {
+      console.log(`Requesting ${peersNeeded} additional peers via PEX`);
+      try {
+        sendPEXRequest(dataChannel, peersNeeded);
+      } catch (error) {
+        console.error("Failed to send PEX request:", error);
+      }
+    } else {
+      console.warn("No open PEX data channels available to send request");
     }
   }
 }

--- a/contexts/db/userdb.ts
+++ b/contexts/db/userdb.ts
@@ -15,6 +15,8 @@ export type User = {
   birthDay?: number;
   birthMonth?: number;
   birthYear?: number;
+  x?: number;
+  y?: number;
 };
  
 export const user_db = SQLite.openDatabase({ name: 'user.db', location: 'default' });
@@ -44,7 +46,9 @@ export const setupUserDatabase = async () => {
           searching TEXT,
           birthDay INTEGER,
           birthMonth INTEGER,
-          birthYear INTEGER
+          birthYear INTEGER,
+          x REAL,
+          y REAL
         )`,
         [],
         () => console.log('Users table created or exists'),
@@ -116,7 +120,9 @@ export const updateUser = async (
       searching,
       birthDay,
       birthMonth,
-      birthYear
+      birthYear,
+      x,
+      y
     } = updates;
 
     // Prepare SQL update fields and values
@@ -171,6 +177,14 @@ export const updateUser = async (
     if (birthYear !== undefined) {
       fields.push('birthYear = ?');
       values.push(birthYear || null);
+    }
+    if (x !== undefined) {
+      fields.push('x = ?');
+      values.push(x || null);
+    }
+    if (y !== undefined) {
+      fields.push('y = ?');
+      values.push(y || null);
     }
 
     if (fields.length === 0) {
@@ -231,7 +245,7 @@ export const saveUserToDB = async (user: User) => {
  
     (await user_db).transaction(tx =>
       tx.executeSql(
-        `INSERT OR REPLACE INTO users (peerId, name, publicKey, aesKey, iv, keyId, profilePic, description, sex, interests, searching, birthDay, birthMonth, birthYear) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT OR REPLACE INTO users (peerId, name, publicKey, aesKey, iv, keyId, profilePic, description, sex, interests, searching, birthDay, birthMonth, birthYear, x, y) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
           user.peerId,
           user.name,
@@ -247,6 +261,8 @@ export const saveUserToDB = async (user: User) => {
           user.birthDay || null,
           user.birthMonth || null,
           user.birthYear || null,
+          user.x || null,
+          user.y || null
         ],
         (_, result) => console.log(`Inserted user ${user.peerId}, rows affected: ${result.rowsAffected}`),
         (_, error) => { throw error; }

--- a/contexts/dht/dht.ts
+++ b/contexts/dht/dht.ts
@@ -198,6 +198,10 @@ class DHT extends EventEmitter {
     return this.buckets;
   }
 
+  public getK(): number {
+    return this.k;
+  }
+
   private findNodeInBuckets(nodeId: string): Node | null {
     const closest = this.buckets.closest(nodeId, this.k);
     for (const node of closest) {

--- a/contexts/dht/forward-strategy.ts
+++ b/contexts/dht/forward-strategy.ts
@@ -1,12 +1,13 @@
 import { Node, RPCMessage } from './webrtc-rpc';
 import { MessageDTO } from '../../app/chat/chatUtils'
 import KBucket from './kbucket';
+import { WebSocketMessage } from '@/types/types';
 
 export interface ForwardStrategy {
   forward(
     sender: string,
     recipient: string,
-    message: MessageDTO,
+    message: MessageDTO | WebSocketMessage,
     buckets: KBucket,
     rpc: { sendMessage: (node: Node, sender: string, recipient: string, message: MessageDTO) => Promise<boolean> },
     k: number,
@@ -22,7 +23,7 @@ export class ForwardToAllCloserForwardStrategy implements ForwardStrategy {
   async forward(
     sender: string,
     recipient: string,
-    message: MessageDTO,
+    message: MessageDTO | WebSocketMessage,
     buckets: KBucket,
     rpc: { sendMessage: (node: Node, sender: string, recipient: string, message: MessageDTO) => Promise<boolean> },
     k: number,
@@ -88,9 +89,9 @@ export class ProbabilisticForwardStrategy implements ForwardStrategy {
   async forward(
     sender: string,
     recipient: string,
-    message: MessageDTO,
+    message: MessageDTO | WebSocketMessage,
     buckets: KBucket,
-    rpc: { sendMessage: (node: Node, sender: string, recipient: string, message: MessageDTO) => Promise<boolean> },
+    rpc: { sendMessage: (node: Node, sender: string, recipient: string, message: MessageDTO, signalingMessage: WebSocketMessage) => Promise<boolean> },
     k: number,
     nodeId: string,
     forwardedMessagesIds: Set<string>,

--- a/contexts/dht/kbucket.ts
+++ b/contexts/dht/kbucket.ts
@@ -55,6 +55,15 @@ class KBucket {
     return distances.slice(0, k).map((d) => d.node);
   }
 
+  public sortClosestToSelf(peerIds: string[]): string[] {
+    const distances = peerIds.map((peerId) => ({
+      peerId,
+      distance: KBucket.xorDistance(this.localId, peerId),
+    }));
+    distances.sort((a, b) => a.distance.localeCompare(b.distance)); // Hex string comparison
+    return distances.map((d) => d.peerId);
+  }
+
   public all(): Node[] {
     return this.buckets.flat();
   }

--- a/contexts/dht/webrtc-rpc.ts
+++ b/contexts/dht/webrtc-rpc.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "events";
 import { RTCDataChannel, MessageEvent } from "react-native-webrtc";
-import { Message, MessageDTO } from '../../app/chat/chatUtils'
+import { MessageDTO } from '../../app/chat/chatUtils';
 import uuid from "react-native-uuid";
 import { WebSocketMessage } from "@/types/types";
 
@@ -9,20 +9,20 @@ interface RPCOptions {
   getDataChannel?: (node: Node) => RTCDataChannel | null;
 }
 
-interface Node {
+export interface Node {
   id: string;
 }
 
-interface RPCMessage {
+export interface RPCMessage {
   type: "ping" | "pong" | "message" | "signaling";
   sender: string;
   recipient?: string;
-  message?: MessageDTO;
-  signalingMessage?: WebSocketMessage;
+  message?: MessageDTO | null;
+  signalingMessage?: WebSocketMessage | null;
   id?: string;
 }
 
-class WebRTCRPC extends EventEmitter {
+export default class WebRTCRPC extends EventEmitter {
   private channels: Map<string, RTCDataChannel>;
   private destroyed: boolean;
   private id: string;
@@ -38,29 +38,29 @@ class WebRTCRPC extends EventEmitter {
     if (this.destroyed || !node.id) return false;
 
     const channel = this.getChannel(node);
-    console.log(channel);
     if (!channel || channel.readyState !== "open") return false;
 
-    console.log("Sending DHT ping to node " + node.id)
+    console.log("Sending DHT ping to node " + node.id);
     return new Promise((resolve) => {
-      try{
-       const pingId = uuid.v4() as string; // Unique ID for this ping
-       channel.send(JSON.stringify({ type: 'ping', sender: this.getId(), id: pingId } as RPCMessage));
-       const onPong = (message: RPCMessage, from: Node) => {
-         if (message.type === 'pong' && message.id === pingId && from.id === node.id) {
-           this.removeListener('message', onPong);
-           resolve(true);
-         }
-       };
-       this.on('message', onPong);
+      try {
+        const pingId = uuid.v4() as string;
+        channel.send(JSON.stringify({ type: 'ping', sender: this.getId(), id: pingId } as RPCMessage));
+        const onPong = (message: RPCMessage, from: Node) => {
+          if (message.type === 'pong' && message.id === pingId && from.id === node.id) {
+            this.removeListener('message', onPong);
+            resolve(true);
+          }
+        };
+        this.on('message', onPong);
 
-       setTimeout(() => {
-         this.removeListener('message', onPong);
-         resolve(false);
-       }, 10_000);
-    } catch (error) {
-      console.log("Error when sending ping: " + error)
-    }
+        setTimeout(() => {
+          this.removeListener('message', onPong);
+          resolve(false);
+        }, 10_000);
+      } catch (error) {
+        console.log("Error when sending ping: " + error);
+        resolve(false);
+      }
     });
   }
 
@@ -68,39 +68,49 @@ class WebRTCRPC extends EventEmitter {
     node: Node,
     sender: string,
     recipient: string,
-    message?: MessageDTO | null,
-    signalingMessage?: WebSocketMessage
+    message: MessageDTO | null = null,
+    signalingMessage: WebSocketMessage | null = null
   ): Promise<boolean> {
     if (this.destroyed) return false;
     const channel = this.getChannel(node);
-    if (!channel) {
+    if (!channel || channel.readyState !== "open") {
+      console.warn(`Data channel to ${node.id} is not open`);
       return false;
     }
-    if (message) {
-      channel.send(
-        JSON.stringify({ type: "message", sender, recipient, message: message } as RPCMessage)
-      );
-    } else {
-      channel.send(
-        JSON.stringify({ type: "signaling", sender, recipient, signalingMessage } as RPCMessage)
-      );
+
+    try {
+      const payload: RPCMessage = {
+        type: signalingMessage ? "signaling" : "message",
+        sender,
+        recipient,
+        message,
+        signalingMessage
+      };
+      channel.send(JSON.stringify(payload));
+      return true;
+    } catch (error) {
+      console.error(`Error sending message to ${node.id}:`, error);
+      return false;
     }
-    return true;
   }
 
   public closeDataChannel(node: Node): void {
-    this.channels.delete(node.id);//todo: close channels and try to reuse them later
+    const channel = this.channels.get(node.id);
+    if (channel) {
+      channel.close();
+      this.channels.delete(node.id);
+    }
   }
 
   public setUpDataChannel(node: Node, dataChannel: RTCDataChannel) {
     dataChannel.onmessage = (event) => {
-      console.log("Recieved Message on DHT datachannel")
+      console.log("Received Message on DHT datachannel");
       this.handleMessage(event, node);
-    }
+    };
     dataChannel.onopen = () => {
       this.emit("listening", node);
       console.log("DHT DataChannel opened with " + node.id);
-    }
+    };
     dataChannel.onerror = (err) => this.emit("warning", err);
     dataChannel.onclose = () => this.channels.delete(node.id);
     this.channels.set(node.id, dataChannel);
@@ -109,28 +119,25 @@ class WebRTCRPC extends EventEmitter {
   private getChannel(node: Node): RTCDataChannel | null {
     let channel = this.channels.get(node.id);
     if (!channel) {
-      console.log("Couldn't retrive datachannel to node " + node.id);
+      console.log("Couldn't retrieve datachannel to node " + node.id);
       return null;
     }
     return channel;
   }
 
   private handleMessage(event: MessageEvent, node: Node): void {
-    console.log("Recived message in DHT from " + node.id);
-    console.log(event);
+    console.log("Received message in DHT from " + node.id);
     try {
       const message: RPCMessage = JSON.parse(event.data as string);
       if (message.type === 'ping') {
-        console.log(this.channels);
-        this.emit('ping', node);
         const channel = this.channels.get(node.id);
-        console.log(message.id);
         if (channel) {
           channel.send(JSON.stringify({ type: 'pong', sender: this.getId(), id: message.id } as RPCMessage));
         }
+        this.emit('ping', node);
       } else if (message.type === 'pong') {
         this.emit('message', message, node);
-      } else if (message.type === "message") {
+      } else if (message.type === "message" || message.type === "signaling") {
         this.emit("message", message, node);
       }
     } catch (e) {
@@ -146,8 +153,6 @@ class WebRTCRPC extends EventEmitter {
     this.destroyed = true;
     for (const channel of this.channels.values()) channel.close();
     this.channels.clear();
+    this.removeAllListeners();
   }
 }
-
-export default WebRTCRPC;
-export { Node, RPCMessage };

--- a/contexts/pex.ts
+++ b/contexts/pex.ts
@@ -78,15 +78,16 @@ const shareConnectedPeers = async (
     if (connections.size !== 0) {
       let count = 0;
       for (const peerId of connections.keys()) {
-        console.log(connections);
-        console.log(maxNumberOfPeers);
         if (maxNumberOfPeers !== undefined && count >= maxNumberOfPeers) {
           break;
         }
-        const user = await fetchUserFromDB(peerId);
-        const publicKey = user?.publicKey!;
-        peersToShare.add({ peerId, publicKey });
-        count++;
+        const iceCandidatesState = connections.get(peerId)?.iceConnectionState;
+        if (iceCandidatesState === "connected" || iceCandidatesState === "completed") {
+          const user = await fetchUserFromDB(peerId);
+          const publicKey = user?.publicKey!;
+          peersToShare.add({ peerId, publicKey });
+          count++;
+        } 
       }
     }
   } catch (err) {

--- a/contexts/pex.ts
+++ b/contexts/pex.ts
@@ -6,6 +6,7 @@ import {
 import { PEXMessage, PEXRequest, PEXAdvertisement, PeerDTO } from "../types/types";
 import { fetchUserFromDB } from "./db/userdb";
 import { ConnectionManager } from "./connection-manger";
+import { calculateAge } from "./utils/user-utils";
 
 export const handlePEXMessages = (
   event: MessageEvent,
@@ -63,7 +64,12 @@ const shareConnectedPeers = async (
         if (iceCandidatesState === "connected" || iceCandidatesState === "completed") {
           const user = await fetchUserFromDB(peerId);
           const publicKey = user?.publicKey!;
-          peersToShare.add({ peerId, publicKey });
+          const age = calculateAge(user?.birthDay!, user?.birthMonth!, user?.birthYear!);
+          const sex = user?.sex;
+          const searching = user?.searching;
+          const x = user?.x;
+          const y = user?.y;
+          peersToShare.add({ peerId, publicKey, age, sex, searching, x, y });
           count++;
         } 
       }

--- a/contexts/pex.ts
+++ b/contexts/pex.ts
@@ -4,6 +4,7 @@ import {
   MessageEvent,
 } from "react-native-webrtc";
 import { PEXMessage, PEXRequest, PEXAdvertisement, PeerDTO } from "../types/types";
+import { fetchUserFromDB } from "./db/userdb";
 
 export const handlePEXMessages = (
   event: MessageEvent,
@@ -16,64 +17,80 @@ export const handlePEXMessages = (
   ) => Promise<void>,
   signalingDataChannel: RTCDataChannel | null
 ): void => {
+  console.log("Received pex message:");
+  console.log(event);
   try {
     const message = JSON.parse(event.data) as PEXMessage;
     if (message.type === "request") {
+      console.log(connections)
       shareConnectedPeers(pexDataChannel, message, connections);
     } else if (message.type === "advertisement") {
-      const receivedPeers: string[] = message.peers;
-      const tableOfPeers: string[] = [];
+      const receivedPeers: PeerDTO[] = message.peers;
+      const tableOfPeers: PeerDTO[] = [];
 
       if (Array.isArray(receivedPeers)) {
-        receivedPeers.forEach((peerId) => {
-          const alreadyConnected = Object.keys(connections).some(
-            (id) => id === peerId
+        receivedPeers.forEach((peerDto) => {
+          const alreadyConnected = [...connections.keys()].some(
+            (id) => id === peerDto.peerId
           );
           if (
-            !tableOfPeers.includes(peerId) &&
+            !tableOfPeers.includes(peerDto) &&
             !alreadyConnected &&
-            peerId !== userPeerId
+            peerDto.peerId !== userPeerId
           ) {
-            tableOfPeers.push(peerId);
+            tableOfPeers.push(peerDto);
           }
         });
       }
 
-      // TODO: share PeerDTOs
-      // tableOfPeers.forEach((peerId) => {
-      //   initiateConnection(peerId, signalingDataChannel);
-      // });
+      tableOfPeers.forEach((peerDto) => {
+        initiateConnection(peerDto, signalingDataChannel);
+      });
     }
   } catch (error) {
     console.error("Error handling PEX request:", error);
   }
 };
 
-export const sendPEXRequest = (pexDataChannel: RTCDataChannel): void => {
+export const sendPEXRequest = (pexDataChannel: RTCDataChannel, requestedPeersNum: number): void => {
   console.log("Sending PEX request");
   const requestMessage: PEXRequest = {
     type: "request",
-    maxNumberOfPeers: 20,
+    maxNumberOfPeers: requestedPeersNum,
   };
 
   try {
-    // pexDataChannel.send(JSON.stringify(requestMessage));
+    pexDataChannel.send(JSON.stringify(requestMessage));
   } catch (error) {
     console.log("Couldn’t send pex request: " + error);
   }
 };
 
-const shareConnectedPeers = (
+const shareConnectedPeers = async (
   pexDataChannel: RTCDataChannel,
   message: PEXRequest,
   connections: Map<string, RTCPeerConnection>
-): void => {
-  // TODO: read requested number of peers from PEXRequest
-  const peersToShare = new Set<string>();
-  if (Object.keys(connections).length !== 0) {
-    Object.keys(connections).forEach((peerId) => {
-      peersToShare.add(peerId);
-    });
+): Promise<void> => {
+  const maxNumberOfPeers = message.maxNumberOfPeers;
+  const peersToShare = new Set<PeerDTO>();
+
+  try {
+    if (connections.size !== 0) {
+      let count = 0;
+      for (const peerId of connections.keys()) {
+        console.log(connections);
+        console.log(maxNumberOfPeers);
+        if (maxNumberOfPeers !== undefined && count >= maxNumberOfPeers) {
+          break;
+        }
+        const user = await fetchUserFromDB(peerId);
+        const publicKey = user?.publicKey!;
+        peersToShare.add({ peerId, publicKey });
+        count++;
+      }
+    }
+  } catch (err) {
+    console.error(err);
   }
 
   const answer: PEXAdvertisement = {

--- a/contexts/signaling.ts
+++ b/contexts/signaling.ts
@@ -397,7 +397,11 @@ export const encryptAndSignOffer = async (
     const sdp = sessionDescription.sdp;
     var { encryptedMessage, authTag } = encodeAndEncryptMessage(sdp, aesKey, iv);
 
+    console.log("Offer encrypted");
+    console.log(encryptedMessage);
     const encryptedAesKey = encryptAesKey(targetPublicKey, aesKey);
+    console.log("AES key encrpyted")
+    console.log(encryptedAesKey)
     const encryptedAesKeySignature = await signMessage(encryptedAesKey);
 
     const payload: OfferMessage = {

--- a/contexts/socket.ts
+++ b/contexts/socket.ts
@@ -77,6 +77,7 @@ export const handleWebSocketMessages = (
 };
 
 export const disconnectSocket = (): void => {
+  console.log("Disconenct triggered")
   if (socket) {
     socket.disconnect();
     socket = null;

--- a/contexts/socket.ts
+++ b/contexts/socket.ts
@@ -2,6 +2,7 @@ import { io, Socket } from "socket.io-client";
 import { handleWebRTCSignaling } from "./signaling";
 import { Peer, WebSocketMessage, ReadyMessage, Profile, PeerDTO } from "../types/types";
 import { RTCPeerConnection, RTCDataChannel } from "react-native-webrtc";
+import { calculateAge } from "./utils/user-utils";
 
 let socket: Socket | null = null;
 
@@ -34,6 +35,7 @@ export const handleWebSocketMessages = (
   socketRef.on("message", (message: WebSocketMessage) => {
     if (message.target === profile.peerId) {
       if ("payload" in message && "connections" in message.payload) {
+        console.log(connections);
         const connectionsPayload: PeerDTO[] = message.payload.connections;
         console.log("Connections");
         console.log(connectionsPayload);
@@ -67,17 +69,27 @@ export const handleWebSocketMessages = (
   });
 
   socketRef.on("connect", () => {
+    console.log("here101")
+    console.log(profile)
+    let age = 0;
+    try {
+      age = calculateAge(profile.birthDay!, profile.birthMonth!, profile.birthYear!);
+    } catch(err) {
+      console.log(err);
+    }
+
+    console.log(age);
     const readyMessage: ReadyMessage = {
-      peerId: profile.peerId,
-      publicKey: profile.publicKey,
+      peerDto: { peerId: profile.peerId, publicKey: profile.publicKey, x: profile.x, y: profile.y, sex: profile.sex, searching: profile.searching, age: age },
       type: "type-emulator",
     };
-    socketRef.emit("ready", readyMessage.peerId, readyMessage.type, readyMessage.publicKey);
+    console.log(readyMessage)
+    socketRef.emit("ready", readyMessage);
   });
 };
 
 export const disconnectSocket = (): void => {
-  console.log("Disconenct triggered")
+  console.log("Disconnect triggered")
   if (socket) {
     socket.disconnect();
     socket = null;

--- a/contexts/utils/user-utils.ts
+++ b/contexts/utils/user-utils.ts
@@ -1,0 +1,26 @@
+export function calculateAge(birthDay: number, birthMonth: number, birthYear: number): number {
+    if (!birthYear || !birthMonth || !birthDay) {
+        throw new Error("Coudln't calculate bithday date: one or more properties are missing");
+    }
+
+    const today = new Date();
+    const birthDate = new Date(birthYear, birthMonth - 1, birthDay);
+
+    // Validate the birth date
+    if (isNaN(birthDate.getTime()) || 
+        birthDate.getFullYear() !== birthYear || 
+        birthDate.getMonth() !== birthMonth - 1 || 
+        birthDate.getDate() !== birthDay) {
+        throw new Error("Validation of birthday date failed");
+    }
+
+    let age = today.getFullYear() - birthDate.getFullYear();
+    const monthDiff = today.getMonth() - birthDate.getMonth();
+    const dayDiff = today.getDate() - birthDate.getDate();
+
+    if (monthDiff < 0 || (monthDiff === 0 && dayDiff < 0)) {
+        age--;
+    }
+
+    return age;
+}

--- a/types/types.ts
+++ b/types/types.ts
@@ -107,8 +107,7 @@ export type WebSocketMessage =
   | BroadcastMessage;
 
 export type ReadyMessage = {
-  peerId: string;
-  publicKey: string;
+  peerDto: PeerDTO;
   type: string;
 };
 
@@ -132,7 +131,12 @@ export type ProfileMessage = {
 export type PeerDTO = {
   peerId: string;
   publicKey: string;
-  // todo - add x, y, sex, geolocation
+  age?: number;
+  x?: number;
+  y?: number;
+  sex?: number[];
+  searching?: number[];
+  // todo - add geolocation
 }
 
 export interface WebRTCContextValue {

--- a/types/types.ts
+++ b/types/types.ts
@@ -118,7 +118,7 @@ export type PEXRequest = {
 
 export type PEXAdvertisement = {
   type: "advertisement";
-  peers: string[];
+  peers: PeerDTO[];
 };
 
 export type PEXMessage = PEXRequest | PEXAdvertisement;

--- a/types/types.ts
+++ b/types/types.ts
@@ -56,6 +56,7 @@ export interface MessageData {
 }
 
 export type WebSocketMessageBase = {
+  id?: string;
   from: string;
   target: string | "all";
 };


### PR DESCRIPTION
- Add Profile Sharing: Public profile information is now shared through the bootstrapping server and during Peer Exchange (PEX) processes, enhancing network discoverability and enabling filtering logic later.
- Signaling over DHT: Added support for signaling over the Distributed Hash Table (DHT), enabling signaling over a couple of hops. Signailing messages are not cached in the DHT.
- ConnectionManager Class: Introduced a new ConnectionManager class to streamline the creation and management of network connections.
- Initial Connection Logic: Implemented the performInitialConnections function to trigger rejoining logic. This includes:
  - Sending PEX requests to the 20 closest peers 2 seconds after application startup.
  - Sending signaling requests over DHT to K * 2 peers after 5 seconds from the app startup, starting from the top of the KBuckets, to re-establish connections within the DHT network.