### PR TITLE
OP-62: Add feature of blocking others

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -108,6 +108,11 @@ const MainScreen: React.FC = () => {
         onPress={() => AsyncStorage.removeItem('@WebRTC:swipeLabels')}
         color="#FF6347"
       />
+      <Button
+        title="Clear blocked peers state"
+        onPress={() => AsyncStorage.removeItem('@WebRTC:blockedPeers')}
+        color="#FF6347"
+      />
       <Text style={styles.title}>Connected Peers</Text>
       <FlatList
         data={peers}

--- a/app/(tabs)/userProfile.tsx
+++ b/app/(tabs)/userProfile.tsx
@@ -114,10 +114,6 @@ const userProfile: React.FC = () => {
       await AsyncStorage.removeItem(`@DHT:${peerIdRef.current}:cachedMessages`);
       deleteGeoPrivateKey()
       removeFiltration()
-      // setProfile(() => null);
-      // setNotifyProfileDeletion((prev) => prev + 1)
-
-      // router.replace('/profile/rules');
       profileEventEmitter.emit('profileDeleted');
     } catch (error) {
       console.error('Error deleting profile:', error);

--- a/components/custom/buttonSettingOtter.tsx
+++ b/components/custom/buttonSettingOtter.tsx
@@ -4,6 +4,7 @@ import { Colors } from '@/constants/Colors';
 import { Fonts } from '@/constants/Fonts';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import TrashIcon from '@/assets/icons/uicons/trash-xmark.svg';
+import CrossIcon from '@/assets/icons/uicons/cross-small.svg';
 import TriangleIcon from '@/assets/icons/uicons/triangle-warning.svg';
 
 interface ButtonSettingOtterProps {
@@ -44,7 +45,15 @@ export default function ButtonSettingOtter({
             style={styles.icon}
           />
         )}
-        <Text style={[styles.buttonTitle, icon === 'trash' && styles.trash, textStyle]}>
+        {icon === 'cross' && (
+          <CrossIcon
+            height={23}
+            width={23}
+            fill={Colors[colorScheme ?? 'light'].deleteIcon}
+            style={styles.icon}
+          />
+        )}
+        <Text style={[styles.buttonTitle, styles.trash, textStyle]}>
           {text}
         </Text>
       </View>
@@ -62,6 +71,7 @@ const getStyles = (colorScheme: 'light' | 'dark') =>
       borderRadius: 20,
       borderWidth: 2,
       borderColor: Colors[colorScheme].border1,
+      marginBottom: 10,
     },
     buttonContent: {
       flexDirection: 'row',
@@ -78,6 +88,10 @@ const getStyles = (colorScheme: 'light' | 'dark') =>
       marginRight: 16,
     },
     trash: {
+      color: Colors[colorScheme].deleteText,
+      fontFamily: Fonts.fontFamilyBold,
+    },
+    cross: {
       color: Colors[colorScheme].deleteText,
       fontFamily: Fonts.fontFamilyBold,
     },

--- a/contexts/connection-manger.ts
+++ b/contexts/connection-manger.ts
@@ -33,6 +33,7 @@ export class ConnectionManager {
   private notifyProfilesChange: () => void;
   private requestedProfiles: Set<string> = new Set();
   private currentSwiperIndexRef: React.MutableRefObject<number>;
+  private blockedPeersRef: React.MutableRefObject<Set<string>>;
   private filteredPeersReadyToDisplay: Set<PeerDTO> = new Set();
   private swipeLabels: SwipeLabel[] = []; // Store last 20 swipe actions
 
@@ -44,6 +45,7 @@ export class ConnectionManager {
     profilesToDisplayRef: MutableRefObject<Profile[]>,
     displayedPeersRef: Set<string>,
     currentSwiperIndexRef: React.MutableRefObject<number>,
+    blockedPeersRef: React.MutableRefObject<Set<string>>,
     setPeers: React.Dispatch<React.SetStateAction<Peer[]>>,
     initiateConnection: (targetPeer: PeerDTO, dataChannelUsedForSignaling?: RTCDataChannel | null) => Promise<void>,
     notifyProfilesChange: () => void
@@ -52,6 +54,7 @@ export class ConnectionManager {
     this.pexDataChannelsRef = pexDataChannelsRef;
     this.dhtRef = dhtRef;
     this.userFilterRef = userFilterRef;
+    this.blockedPeersRef = blockedPeersRef;
     this.displayedPeersRef = displayedPeersRef;
     this.currentSwiperIndexRef = currentSwiperIndexRef;
     this.profilesToDisplayRef = profilesToDisplayRef;
@@ -395,7 +398,8 @@ export class ConnectionManager {
         if (
           !tableOfPeers.includes(peerDto) &&
           !alreadyConnected &&
-          peerDto.peerId !== this.dhtRef.getNodeId()
+          peerDto.peerId !== this.dhtRef.getNodeId() &&
+          !this.blockedPeersRef.current.has(peerDto.peerId)
         ) {
           tableOfPeers.push(peerDto);
         }

--- a/contexts/dht/kbucket.ts
+++ b/contexts/dht/kbucket.ts
@@ -46,6 +46,22 @@ class KBucket {
     console.log(this.buckets);
   }
 
+  public remove(nodeId: string): boolean {
+    if (nodeId === this.localId) return false;
+    try {
+      const distance = KBucket.xorDistance(this.localId, nodeId);
+      const bucketIndex = this.bucketIndex(distance);
+      const bucket = this.buckets[bucketIndex];
+      const initialLength = bucket.length;
+      this.buckets[bucketIndex] = bucket.filter((n) => n.id !== nodeId);
+      console.log(`Removed node ${nodeId} from bucket ${bucketIndex}`);
+      return bucket.length < initialLength;
+    } catch (error) {
+      console.log(`ERROR removing node ${nodeId}: ${error}`);
+      return false;
+    }
+  }
+
   public closest(target: string, k: number = this.k): Node[] {
     const distances = this.all().map((node) => ({
       node,

--- a/contexts/socket.ts
+++ b/contexts/socket.ts
@@ -24,6 +24,7 @@ export const handleWebSocketMessages = (
   profile: Profile,
   connections: Map<string, RTCPeerConnection>,
   connectionManager: ConnectionManager,
+  blockedPeersRef: React.MutableRefObject<Set<string>>,
   createPeerConnection: (
     targetPeer: PeerDTO,
     signalingDataChannel?: RTCDataChannel | null
@@ -47,7 +48,8 @@ export const handleWebSocketMessages = (
           createPeerConnection,
           connectionManager,
           setPeers,
-          socketRef
+          socketRef,
+          blockedPeersRef
         );
       }
     } else if (message.target === "all") {
@@ -62,8 +64,6 @@ export const handleWebSocketMessages = (
   });
 
   socketRef.on("connect", () => {
-    console.log("Connecting to Signaling serwer")
-    console.log(profile);
     let age = 0;
     try {
       age = calculateAge(profile.birthDay!, profile.birthMonth!, profile.birthYear!);

--- a/types/types.ts
+++ b/types/types.ts
@@ -200,4 +200,5 @@ export interface WebRTCContextValue {
   likedPeersRef: React.MutableRefObject<Set<string>>;
   displayedPeersRef: React.MutableRefObject<Set<string>>;
   setNotifyProfileCreation: React.Dispatch<React.SetStateAction<number>>;
+  blockPeer: (peerId: string) => void;
 }


### PR DESCRIPTION
# Changelog: Enhanced Blocking Functionality for Chat Profile Page

The following enhancements are introduced:

- **Add Block User Button**: Introduce a "Zablokuj osobę" button on the chat profile page to enable users to block unwanted contacts with a single tap (plus the confirmation alert).
- **Store Blocked Peers Persistently**: Add the `peerId` of a blocked user to the `blockedPeersRef` list and save it in AsyncStorage to ensure persistent blocking across sessions.
- **Prevent Signaling for Blocked Peers**: Drop signaling messages from blocked peers in the `handleWebRTCSignaling` function in `signaling.ts` to prevent connections.
- **Block New Connection Attempts**: Avoid initiating new connections to blocked peers to maintain isolation.
- **Remove Blocked Peers from DHT**: Clear blocked peers from the DHT's KBuckets to optimize and secure the peer network.
- **Filter Messages from Blocked Peers**: Discard messages received via DHT from blocked peers and prevent their storage in the database to keep the user's inbox clean.

![image](https://github.com/user-attachments/assets/590772c9-1e04-47bd-938f-ef9c298a1fd5)
