### PR TITLE
OP-46: Add connections limit + fix issues found during testing

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -43,7 +43,7 @@ export default function TabLayout() {
             backgroundColor: theme.background1,
           },
           android: {
-            height: 80,
+            height: 58,
             paddingTop: 8,
             paddingBottom: 0,
             borderTopWidth: 0,

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -38,8 +38,10 @@ const MainScreen: React.FC = () => {
 
   const clearDHTState = async () => {
     try {
+      dhtRef.current?.removeAllNodesFromBuckets();
       await AsyncStorage.removeItem(`@DHT:${peerIdRef.current}:kBucket`);
       await AsyncStorage.removeItem(`@DHT:${peerIdRef.current}:cachedMessages`);
+
       console.log('DHT state cleared successfully');
     } catch (error) {
       console.error('Error clearing DHT state:', error);

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -31,7 +31,8 @@ type RootStackParamList = {
 const profileEventEmitter = new EventEmitter();
 
 export default function RootLayout() {
-  const signalingServerURL = process.env.EXPO_PUBLIC_SIGNALING_SERVER_URL;
+  const signalingServerURL = "http://10.0.2.2:3030";
+  // const signalingServerURL = process.env.EXPO_PUBLIC_SIGNALING_SERVER_URL;
   const TOKEN = process.env.EXPO_PUBLIC_SIGNALING_SERVER_TOKEN;
   const TURN_PASSWORD = process.env.EXPO_PUBLIC_TURN_PASSWORD;
   const TURN_SERVER_URL = process.env.EXPO_PUBLIC_TURN_SERVER_URL;

--- a/contexts/WebRTCContext.tsx
+++ b/contexts/WebRTCContext.tsx
@@ -152,7 +152,7 @@ export const WebRTCProvider: React.FC<WebRTCProviderProps> = ({ children, signal
 
   const cleanOldLocalCandidates = () => {
     const now = Date.now();
-    const maxAge = 15 * 1000; // 15 seconds
+    const maxAge = 30 * 1000; // 15 seconds
     localIceCandidateQueue.current.forEach((queue, peerId) => {
       const filteredQueue = queue.filter((candidate) => now - candidate.timestamp < maxAge);
       if (filteredQueue.length > 0) {

--- a/contexts/WebRTCContext.tsx
+++ b/contexts/WebRTCContext.tsx
@@ -172,7 +172,7 @@ export const WebRTCProvider: React.FC<WebRTCProviderProps> = ({ children, signal
       const dataChannel: RTCDataChannel = event.channel;
       if (dataChannel.label === 'chat') {
         chatDataChannelsRef.current.set(targetPeer.peerId, dataChannel);
-        initiateDBTable(targetPeer.peerId, dataChannel);
+        // initiateDBTable(targetPeer.peerId, dataChannel);
         receiveMessageFromChat(dataChannel, dhtRef.current!, setNotifyChat);
         const originalClose = dataChannel.close.bind(dataChannel);
         dataChannel.close = () => {
@@ -229,7 +229,7 @@ export const WebRTCProvider: React.FC<WebRTCProviderProps> = ({ children, signal
         };
         dataChannel.onmessage = async (event: MessageEvent) => {
           console.log('received message on signalingDataChannel - answer side' + event);
-          handleSignalingOverDataChannels(JSON.parse(event.data) as WebSocketMessage, profile!, connectionsRef.current, createPeerConnection,
+          handleSignalingOverDataChannels(JSON.parse(event.data) as WebSocketMessage, profileRef.current!, connectionsRef.current, createPeerConnection,
             setPeers, signalingDataChannelsRef.current, connectionManagerRef, blockedPeersRef, dataChannel);
         };
         dataChannel.onclose = () => {
@@ -417,7 +417,7 @@ export const WebRTCProvider: React.FC<WebRTCProviderProps> = ({ children, signal
 
     const chatDataChannel = peerConnection.createDataChannel('chat');
     chatDataChannelsRef.current.set(targetPeer.peerId, chatDataChannel);
-    initiateDBTable(targetPeer.peerId, chatDataChannel);
+    // initiateDBTable(targetPeer.peerId, chatDataChannel);
     receiveMessageFromChat(chatDataChannel, dhtRef.current!, setNotifyChat);
     const originalClose = chatDataChannel.close.bind(chatDataChannel);
     chatDataChannel.close = () => {
@@ -433,9 +433,14 @@ export const WebRTCProvider: React.FC<WebRTCProviderProps> = ({ children, signal
       signalingDataChannelsRef.current.set(targetPeer.peerId, signalingDataChannel);
     };
     signalingDataChannel.onmessage = async (event: MessageEvent) => {
-      console.log('received message on signalingDataChannel - offer side' + event);
-      handleSignalingOverDataChannels(JSON.parse(event.data) as WebSocketMessage, profile!, connectionsRef.current, createPeerConnection,
+      console.log('received message on signalingDataChannel - offer side' + event.data);
+      try {
+        handleSignalingOverDataChannels(JSON.parse(event.data) as WebSocketMessage, profileRef.current!, connectionsRef.current, createPeerConnection,
         setPeers, signalingDataChannelsRef.current, connectionManagerRef, blockedPeersRef, signalingDataChannel);
+      } catch(err) {
+        console.error(err)
+      }
+
     };
 
     const pexDataChannel = peerConnection.createDataChannel('pex');

--- a/contexts/WebRTCContext.tsx
+++ b/contexts/WebRTCContext.tsx
@@ -629,6 +629,7 @@ export const WebRTCProvider: React.FC<WebRTCProviderProps> = ({ children, signal
           displayedPeersRef.current,
           currentSwiperIndexRef,
           blockedPeersRef,
+          profileRef,
           setPeers,
           initiateConnection,
           notifyProfilesChange

--- a/contexts/__tests__/connection-manager.test.ts
+++ b/contexts/__tests__/connection-manager.test.ts
@@ -1,15 +1,37 @@
-
 import { ConnectionManager } from '../connection-manger';
 import { PeerDTO, Profile, SwipeLabel } from '../../types/types';
 import { trainModel, predictModel } from '../ai/knn';
 import { generateRandomPeers } from '../utils/generate-random-peers';
 import { MutableRefObject } from 'react';
 import DHT from '../dht/dht';
+import { RTCPeerConnection } from 'react-native-webrtc';
+import KBucket from '../dht/kbucket';
 
 // Mock native modules
 jest.mock('react-native-sqlite-storage');
 jest.mock('@react-native-async-storage/async-storage');
-jest.mock('react-native-webrtc');
+jest.mock('react-native-webrtc', () => ({
+  RTCPeerConnection: jest.fn().mockImplementation(() => ({
+    close: jest.fn(),
+    iceConnectionState: 'connected',
+    createDataChannel: jest.fn().mockReturnValue({
+      readyState: 'open',
+      send: jest.fn(),
+      close: jest.fn(),
+    }),
+  })),
+  RTCDataChannel: jest.fn(),
+}));
+jest.mock('react-native', () => {
+  const rn = jest.requireActual('react-native');
+  return {
+    ...rn,
+    Appearance: {
+      getColorScheme: jest.fn(() => 'light'),
+      addChangeListener: jest.fn(() => ({ remove: jest.fn() })),
+    },
+  };
+});
 
 // Mock DHT dependencies
 jest.mock('../dht/dht', () => {
@@ -18,6 +40,19 @@ jest.mock('../dht/dht', () => {
     findNode: jest.fn(),
     addNode: jest.fn(),
     removeNode: jest.fn(),
+    getBuckets: jest.fn(() => ({
+      all: jest.fn(() => []),
+      sortClosestToSelf: jest.fn((peerIds) => peerIds), // Preserve order for simplicity
+    })),
+  }));
+});
+
+// Mock KBucket
+jest.mock('../dht/kbucket', () => {
+  return jest.fn().mockImplementation(() => ({
+    all: jest.fn(() => []),
+    sortClosestToSelf: jest.fn((peerIds) => peerIds.slice().sort()), // Simple sort for deterministic tests
+    remove: jest.fn(),
   }));
 });
 
@@ -26,8 +61,15 @@ const mockInitiateConnection = jest.fn();
 const mockSetPeers = jest.fn();
 const mockNotifyProfilesChange = jest.fn();
 
-describe('ConnectionManager - rankPeers', () => {
+describe('ConnectionManager', () => {
   let connectionManager: ConnectionManager;
+  let connectionsRef: Map<string, RTCPeerConnection>;
+  let pexDataChannelsRef: Map<string, any>;
+  let dhtRef: DHT;
+  let profilesToDisplayRef: MutableRefObject<Profile[]>;
+  let currentSwiperIndexRef: MutableRefObject<number>;
+  let blockedPeersRef: MutableRefObject<Set<string>>;
+  let userFilterRef: MutableRefObject<any>;
 
   // Sample swipeLabels used for training the knn model
   const swipeLabels: SwipeLabel[] = [
@@ -57,30 +99,38 @@ describe('ConnectionManager - rankPeers', () => {
   const peers: PeerDTO[] = generateRandomPeers(5);
 
   beforeEach(() => {
-    // Reset mocks
     jest.clearAllMocks();
 
     // Create mock refs
-    const currentSwiperIndexRef: MutableRefObject<number> = { current: 0 };
-    const profilesToDisplayRef: MutableRefObject<Profile[]> = { current: [] };
-    const userFilterRef: MutableRefObject<any> = { current: {} };
+    connectionsRef = new Map();
+    pexDataChannelsRef = new Map();
+    profilesToDisplayRef = { current: [] };
+    currentSwiperIndexRef = { current: 0 };
+    userFilterRef = { current: {} };
+    blockedPeersRef = { current: new Set() };
+
+    // Instantiate DHT
+    dhtRef = new DHT({ nodeId: 'self', k: 20 }, blockedPeersRef);
 
     // Instantiate ConnectionManager
     connectionManager = new ConnectionManager(
-      new Map(),
-      new Map(),
-      new DHT({ nodeId: 'self', k: 20 }),
+      connectionsRef,
+      pexDataChannelsRef,
+      dhtRef,
       userFilterRef,
       profilesToDisplayRef,
       new Set(),
       currentSwiperIndexRef,
+      blockedPeersRef,
       mockSetPeers,
       mockInitiateConnection,
       mockNotifyProfilesChange
     );
 
+    // Set internal properties
     (connectionManager as any).swipeLabels = swipeLabels;
     (connectionManager as any).minConnections = 20;
+    (connectionManager as any).maxConnections = 100;
     (connectionManager as any).maxBufferSize = 20;
     (connectionManager as any).minBufferSize = 10;
     (connectionManager as any).swipeThreshold = 10;
@@ -126,4 +176,249 @@ describe('ConnectionManager - rankPeers', () => {
     const result = await connectionManager['rankPeers']([]);
     expect(result).toEqual([]);
   });
+
+  // describe('Connection Limiting', () => {
+  //   beforeEach(() => {
+  //     // Reset mocks and state
+  //     connectionsRef.clear();
+  //     pexDataChannelsRef.clear();
+  //     profilesToDisplayRef.current = [];
+  //     (connectionManager as any).filteredPeersReadyToDisplay.clear();
+  //     connectionManager.stop(); // Clear failedRequestPeers via stop method
+  //     mockInitiateConnection.mockReset();
+  //     (dhtRef.getBuckets().all as jest.Mock).mockReset();
+  //     (dhtRef.getBuckets().sortClosestToSelf as jest.Mock).mockReset();
+  //   });
+
+  //   it('should not disconnect peers when connections are below or at limit', async () => {
+  //     // Setup 100 connections (at limit)
+  //     for (let i = 0; i < 100; i++) {
+  //       const peerId = `peer${i}`;
+  //       connectionsRef.set(peerId, new RTCPeerConnection({}));
+  //       pexDataChannelsRef.set(peerId, { readyState: 'open', send: jest.fn(), close: jest.fn() });
+  //     }
+
+  //     await (connectionManager as any).checkAndLimitConnections();
+  //     expect(connectionsRef.size).toBe(100);
+  //     expect(dhtRef.removeNode).not.toHaveBeenCalled();
+  //   });
+
+  //   it('should disconnect excess peers not in use when over limit', async () => {
+  //     // Setup 101 connections (1 over limit)
+  //     for (let i = 0; i < 101; i++) {
+  //       const peerId = `peer${i}`;
+  //       connectionsRef.set(peerId, new RTCPeerConnection({}));
+  //       pexDataChannelsRef.set(peerId, { readyState: 'open', send: jest.fn(), close: jest.fn() });
+  //     }
+
+  //     await (connectionManager as any).checkAndLimitConnections();
+  //     expect(connectionsRef.size).toBe(100);
+  //     expect(dhtRef.removeNode).toHaveBeenCalledTimes(1);
+  //     expect(mockNotifyProfilesChange).not.toHaveBeenCalled(); // No profiles affected
+  //   });
+
+  //   it('should preserve peers in filteredPeersReadyToDisplay', async () => {
+  //     // Setup 101 connections
+  //     for (let i = 0; i < 101; i++) {
+  //       const peerId = `peer${i}`;
+  //       connectionsRef.set(peerId, new RTCPeerConnection({}));
+  //       pexDataChannelsRef.set(peerId, { readyState: 'open', send: jest.fn(), close: jest.fn() });
+  //     }
+
+  //     // Add some peers to filteredPeersReadyToDisplay
+  //     const protectedPeers = [
+  //       { peerId: 'peer0', publicKey: 'pub0' },
+  //       { peerId: 'peer1', publicKey: 'pub1' },
+  //     ];
+  //     protectedPeers.forEach(peer => {
+  //       (connectionManager as any).filteredPeersReadyToDisplay.add(peer);
+  //     });
+
+  //     await (connectionManager as any).checkAndLimitConnections();
+  //     expect(connectionsRef.size).toBe(100);
+  //     expect(connectionsRef.has('peer0')).toBe(true);
+  //     expect(connectionsRef.has('peer1')).toBe(true);
+  //     expect(dhtRef.removeNode).toHaveBeenCalledTimes(1);
+  //     expect(dhtRef.removeNode).not.toHaveBeenCalledWith('peer0');
+  //     expect(dhtRef.removeNode).not.toHaveBeenCalledWith('peer1');
+  //   });
+
+  //   it('should preserve peers in profilesToDisplayRef after currentSwiperIndex', async () => {
+  //     // Setup 101 connections
+  //     for (let i = 0; i < 101; i++) {
+  //       const peerId = `peer${i}`;
+  //       connectionsRef.set(peerId, new RTCPeerConnection({}));
+  //       pexDataChannelsRef.set(peerId, { readyState: 'open', send: jest.fn(), close: jest.fn() });
+  //     }
+
+  //     // Add profiles to profilesToDisplayRef
+  //     profilesToDisplayRef.current = [
+  //       { peerId: 'peer0', name: 'Peer0' } as Profile,
+  //       { peerId: 'peer1', name: 'Peer1' } as Profile,
+  //       { peerId: 'peer2', name: 'Peer2' } as Profile,
+  //     ];
+  //     currentSwiperIndexRef.current = 1; // Protect peer1, peer2
+
+  //     await (connectionManager as any).checkAndLimitConnections();
+  //     expect(connectionsRef.size).toBe(100);
+  //     expect(connectionsRef.has('peer1')).toBe(true);
+  //     expect(connectionsRef.has('peer2')).toBe(true);
+  //     expect(dhtRef.removeNode).toHaveBeenCalledTimes(1);
+  //     expect(dhtRef.removeNode).not.toHaveBeenCalledWith('peer1');
+  //     expect(dhtRef.removeNode).not.toHaveBeenCalledWith('peer2');
+  //   });
+
+  //   it('should preserve peers in DHT buckets', async () => {
+  //     // Setup 101 connections
+  //     for (let i = 0; i < 101; i++) {
+  //       const peerId = `peer${i}`;
+  //       connectionsRef.set(peerId, new RTCPeerConnection({}));
+  //       pexDataChannelsRef.set(peerId, { readyState: 'open', send: jest.fn(), close: jest.fn() });
+  //     }
+
+  //     // Mock DHT buckets
+  //     (dhtRef.getBuckets().all as jest.Mock).mockReturnValue([
+  //       { id: 'peer0' },
+  //       { id: 'peer1' },
+  //     ]);
+
+  //     await (connectionManager as any).checkAndLimitConnections();
+  //     expect(connectionsRef.size).toBe(100);
+  //     expect(connectionsRef.has('peer0')).toBe(true);
+  //     expect(connectionsRef.has('peer1')).toBe(true);
+  //     expect(dhtRef.removeNode).toHaveBeenCalledTimes(1);
+  //     expect(dhtRef.removeNode).not.toHaveBeenCalledWith('peer0');
+  //     expect(dhtRef.removeNode).not.toHaveBeenCalledWith('peer1');
+  //   });
+
+  //   it('should disconnect furthest peer when all peers are in use', async () => {
+  //     // Setup 101 connections
+  //     for (let i = 0; i < 101; i++) {
+  //       const peerId = `peer${i}`;
+  //       connectionsRef.set(peerId, new RTCPeerConnection({}));
+  //       pexDataChannelsRef.set(peerId, { readyState: 'open', send: jest.fn(), close: jest.fn() });
+  //     }
+
+  //     // All peers are in filteredPeersReadyToDisplay
+  //     for (let i = 0; i < 101; i++) {
+  //       (connectionManager as any).filteredPeersReadyToDisplay.add({ peerId: `peer${i}`, publicKey: `pub${i}` });
+  //     }
+
+  //     // Mock sortClosestToSelf to return peers in reverse order (peer100 is furthest)
+  //     (dhtRef.getBuckets().sortClosestToSelf as jest.Mock).mockImplementation((peerIds) => peerIds.slice().sort().reverse());
+
+  //     await (connectionManager as any).checkAndLimitConnections();
+  //     expect(connectionsRef.size).toBe(100);
+  //     expect(connectionsRef.has('peer100')).toBe(false);
+  //     expect(dhtRef.removeNode).toHaveBeenCalledWith('peer100');
+  //   });
+
+  //   it('should disconnect oldest peer as fallback when no other peers can be disconnected', async () => {
+  //     // Setup 101 connections
+  //     for (let i = 0; i < 101; i++) {
+  //       const peerId = `peer${i}`;
+  //       connectionsRef.set(peerId, new RTCPeerConnection({}));
+  //       pexDataChannelsRef.set(peerId, { readyState: 'open', send: jest.fn(), close: jest.fn() });
+  //     }
+
+  //     // All peers are in profilesToDisplayRef
+  //     profilesToDisplayRef.current = Array.from({ length: 101 }, (_, i) => ({
+  //       peerId: `peer${i}`,
+  //       name: `Peer${i}`,
+  //     } as Profile));
+  //     currentSwiperIndexRef.current = 0;
+
+  //     // Mock sortClosestToSelf to return empty array (no disconnectable peers)
+  //     (dhtRef.getBuckets().sortClosestToSelf as jest.Mock).mockReturnValue([]);
+
+  //     await (connectionManager as any).checkAndLimitConnections();
+  //     expect(connectionsRef.size).toBe(100);
+  //     expect(connectionsRef.has('peer0')).toBe(false); // Oldest peer disconnected
+  //     expect(dhtRef.removeNode).toHaveBeenCalledWith('peer0');
+  //   });
+
+  //   it('should respect maxConnections in handleNewPeers', async () => {
+  //     // Setup 100 connections (at limit)
+  //     for (let i = 0; i < 100; i++) {
+  //       const peerId = `peer${i}`;
+  //       connectionsRef.set(peerId, new RTCPeerConnection({}));
+  //       pexDataChannelsRef.set(peerId, { readyState: 'open', send: jest.fn(), close: jest.fn() });
+  //     }
+
+  //     const newPeers: PeerDTO[] = [
+  //       { peerId: 'newPeer1', publicKey: 'pub1' },
+  //       { peerId: 'newPeer2', publicKey: 'pub2' },
+  //     ];
+
+  //     await connectionManager.handleNewPeers(newPeers, null);
+  //     expect(mockInitiateConnection).not.toHaveBeenCalled();
+  //     expect(connectionsRef.size).toBe(100);
+  //   });
+
+  //   it('should allow new connections when under maxConnections in handleNewPeers', async () => {
+  //     // Setup 99 connections (below limit)
+  //     for (let i = 0; i < 99; i++) {
+  //       const peerId = `peer${i}`;
+  //       connectionsRef.set(peerId, new RTCPeerConnection({}));
+  //       pexDataChannelsRef.set(peerId, { readyState: 'open', send: jest.fn(), close: jest.fn() });
+  //     }
+
+  //     const newPeers: PeerDTO[] = [
+  //       { peerId: 'newPeer1', publicKey: 'pub1' },
+  //       { peerId: 'newPeer2', publicKey: 'pub2' },
+  //     ];
+
+  //     // Mock filterPeer to allow all peers
+  //     jest.spyOn(connectionManager as any, 'filterPeer').mockReturnValue(true);
+
+  //     await connectionManager.handleNewPeers(newPeers, null);
+  //     expect(mockInitiateConnection).toHaveBeenCalledTimes(1); // Only 1 slot available
+  //     expect(mockInitiateConnection).toHaveBeenCalledWith(newPeers[0], null, false);
+  //   });
+
+  //   it('should respect maxConnections in tryToRestoreDHTConnections', async () => {
+  //     // Setup 100 connections (at limit)
+  //     for (let i = 0; i < 100; i++) {
+  //       const peerId = `peer${i}`;
+  //       connectionsRef.set(peerId, new RTCPeerConnection({}));
+  //       pexDataChannelsRef.set(peerId, { readyState: 'open', send: jest.fn(), close: jest.fn() });
+  //     }
+
+  //     (dhtRef.getBuckets().all as jest.Mock).mockReturnValue([
+  //       { id: 'newPeer1' },
+  //       { id: 'newPeer2' },
+  //     ]);
+
+  //     await (connectionManager as any).tryToRestoreDHTConnections(5);
+  //     expect(mockInitiateConnection).not.toHaveBeenCalled();
+  //     expect(connectionsRef.size).toBe(100);
+  //   });
+
+  //   it('should allow new connections when under maxConnections in tryToRestoreDHTConnections', async () => {
+  //     // Setup 99 connections (below limit)
+  //     for (let i = 0; i < 99; i++) {
+  //       const peerId = `peer${i}`;
+  //       connectionsRef.set(peerId, new RTCPeerConnection({}));
+  //       pexDataChannelsRef.set(peerId, { readyState: 'open', send: jest.fn(), close: jest.fn() });
+  //     }
+
+  //     (dhtRef.getBuckets().all as jest.Mock).mockReturnValue([
+  //       { id: 'newPeer1' },
+  //       { id: 'newPeer2' },
+  //     ]);
+
+  //     // Mock fetchUserFromDB
+  //     jest.spyOn(require('../db/userdb'), 'fetchUserFromDB').mockImplementation(async (peerId) => ({
+  //       publicKey: `pub_${peerId}`,
+  //     }));
+
+  //     await (connectionManager as any).tryToRestoreDHTConnections(5);
+  //     expect(mockInitiateConnection).toHaveBeenCalledTimes(1); // Only 1 slot available
+  //     expect(mockInitiateConnection).toHaveBeenCalledWith(
+  //       { peerId: 'newPeer1', publicKey: 'pub_newPeer1' },
+  //       null,
+  //       true
+  //     );
+  //   });
+  // });
 });

--- a/contexts/connection-manger.ts
+++ b/contexts/connection-manger.ts
@@ -119,7 +119,7 @@ export class ConnectionManager {
     await delay(3000);
     console.log("Trying to restore DHT connections.");
     // await this.tryToRestoreDHTConnections(this.dhtRef['k'] as number);
-    await this.tryToRestoreDHTConnections(20);
+    // await this.tryToRestoreDHTConnections(20);
     this.rankAndAddPeers();
     this.hasTriggeredInitialConnections = true;
   }
@@ -720,6 +720,7 @@ export class ConnectionManager {
           };
           console.log(`Attempting connection to peer ${peer.id} using signaling over DHT`);
           await this.initiateConnection(peerDTO, null, true);
+          this.triggerFilteringAndPeerDTOFetch(peer.id);
           peersAttempted++;
         }
       }

--- a/contexts/connection-manger.ts
+++ b/contexts/connection-manger.ts
@@ -119,7 +119,7 @@ export class ConnectionManager {
     await delay(3000);
     console.log("Trying to restore DHT connections.");
     // await this.tryToRestoreDHTConnections(this.dhtRef['k'] as number);
-    // await this.tryToRestoreDHTConnections(5);
+    await this.tryToRestoreDHTConnections(20);
     this.rankAndAddPeers();
     this.hasTriggeredInitialConnections = true;
   }
@@ -709,6 +709,7 @@ export class ConnectionManager {
       const nodeId = this.dhtRef.getNodeId();
       let peersAttempted = 0;
       for (const peer of nodesInBuckets) {
+        await delay(1000 * Math.random() + 500); // 1s +/-0.5s
         if (peersAttempted > peersToConnect) {
           break;
         }
@@ -717,7 +718,7 @@ export class ConnectionManager {
             peerId: peer.id,
             publicKey: (await fetchUserFromDB(peer.id))?.publicKey!
           };
-          console.log(`Attempting connection to peer ${peer.id}`);
+          console.log(`Attempting connection to peer ${peer.id} using signaling over DHT`);
           await this.initiateConnection(peerDTO, null, true);
           peersAttempted++;
         }

--- a/contexts/connection-manger.ts
+++ b/contexts/connection-manger.ts
@@ -118,7 +118,8 @@ export class ConnectionManager {
     this.performPEXRequestToClosestPeer(this.minConnections);
     await delay(3000);
     console.log("Trying to restore DHT connections.");
-    await this.tryToRestoreDHTConnections(this.dhtRef['k'] as number);
+    // await this.tryToRestoreDHTConnections(this.dhtRef['k'] as number);
+    // await this.tryToRestoreDHTConnections(5);
     this.rankAndAddPeers();
     this.hasTriggeredInitialConnections = true;
   }
@@ -211,7 +212,7 @@ export class ConnectionManager {
           }
         }
       } catch (error) {
-        console.error(`Failed to fetch profile for ${peerDto.peerId}:`, error);
+        // console.error(`Failed to fetch profile for ${peerDto.peerId}:`, error);
       }
       index += 1;
     }
@@ -265,7 +266,7 @@ export class ConnectionManager {
     return sortedPeers;
 
     } catch (err) {
-      console.error(err);
+      // console.error(err);
     }
     console.log("Failover to random ranking");
     return peers.sort(() => Math.random() - 0.5);
@@ -320,7 +321,7 @@ export class ConnectionManager {
           }
         }
       } catch (error) {
-        console.error(`Failed to fetch profile for ${peerDto.peerId}:`, error);
+        // console.error(`Failed to fetch profile for ${peerDto.peerId}:`, error);
       }
     }
   }
@@ -332,7 +333,7 @@ export class ConnectionManager {
       try {
         sendPEXRequest(dataChannel, peersRequested);
       } catch (error) {
-        console.error("Failed to send PEX request:", error);
+        // console.error("Failed to send PEX request:", error);
       }
     } else {
       console.warn("No open PEX data channels available to send request");
@@ -540,7 +541,7 @@ export class ConnectionManager {
         await updateUser(peerId, peerDto);
         return peerDto;
       } catch (error) {
-        console.error(`Attempt ${attempt} failed for peer ${peerId}:`, error);
+        // console.error(`Attempt ${attempt} failed for peer ${peerId}:`, error);
         if (attempt < retries) {
           const delayMs = backoffMs * Math.pow(2, attempt);
           console.log(`Retrying PeerDTO request for ${peerId} after ${delayMs}ms`);
@@ -554,7 +555,7 @@ export class ConnectionManager {
       const peerDto = await tryRequest(1);
       return peerDto;
     } catch (error) {
-      console.error(`Failed to request PeerDTO from peer ${peerId} after ${retries} attempts:`, error);
+      console.error(`Failed to request PeerDTO from peer ${peerId} after ${retries} attempts, closing connection:`, error);
       this.connectionsRef.get(peerId)?.close();
       return null;
     } finally {
@@ -644,7 +645,7 @@ export class ConnectionManager {
         await updateUser(peerId, profile);
         return profile;
       } catch (error) {
-        console.error(`Attempt ${attempt} failed for peer ${peerId}:`, error);
+        // console.error(`Attempt ${attempt} failed for peer ${peerId}:`, error);
         if (attempt < retries) {
           const delayMs = backoffMs * Math.pow(2, attempt);
           console.log(`Retrying profile request for ${peerId} after ${delayMs}ms`);
@@ -658,7 +659,7 @@ export class ConnectionManager {
       const profile = await tryRequest(1);
       return profile;
     } catch (error) {
-      console.error(`Failed to request profile from peer ${peerId} after ${retries} attempts:`, error);
+      console.error(`Failed to request profile from peer ${peerId} after ${retries} attempts, closing connection:`, error);
       this.removePeerFromProfilesToDisplay(peerId);
       this.filteredPeersReadyToDisplay = new Set(
         Array.from(this.filteredPeersReadyToDisplay).filter((peerDto) => peerDto.peerId !== peerId)

--- a/contexts/dht/dht.ts
+++ b/contexts/dht/dht.ts
@@ -203,6 +203,13 @@ class DHT extends EventEmitter {
     }
   }
 
+  public removeAllNodesFromBuckets() {
+    const nodesInBuckets = this.getBuckets().all() as Node[];
+    for (const node of nodesInBuckets) {
+      this.buckets.remove(node.id);
+    }
+  }
+
   public getNodeId(): string {
     return this.nodeId;
   }
@@ -366,6 +373,7 @@ class DHT extends EventEmitter {
         this.cacheStrategy.addCachedMessages(new Map(messagesArray));
       }
 
+      console.log(this.nodeId)
       const nodesJson = await AsyncStorage.getItem(`@DHT:${this.nodeId}:kBucket`);
       if (nodesJson) {
         const nodes: Node[] = JSON.parse(nodesJson);

--- a/contexts/dht/forward-strategy.ts
+++ b/contexts/dht/forward-strategy.ts
@@ -69,7 +69,7 @@ export class ForwardToAllCloserForwardStrategy implements ForwardStrategy {
       });
     }
 
-    console.log(`Forwarding message to ${peersToForward.length} peers: ${peersToForward.map(n => n.id).join(', ')}`);
+    // console.log(`Forwarding message to ${peersToForward.length} peers: ${peersToForward.map(n => n.id).join(', ')}`);
 
     let forwarded = false;
     try {

--- a/contexts/dht/kbucket.ts
+++ b/contexts/dht/kbucket.ts
@@ -9,7 +9,7 @@ class KBucket {
   constructor(localId: string, k: number = 20) {
     this.buckets = Array(160)
       .fill(null)
-      .map(() => []); // 160 bits max for SHA-1-like IDs
+      .map(() => []);
     this.localId = localId;
     this.k = k;
   }
@@ -22,10 +22,9 @@ class KBucket {
     return result.toString("hex");
   }
 
-  // Add a node to the appropriate bucket
   public add(node: Node): void {
     console.log("Adding node " + node.id + " to the DHT");
-    if (node.id === this.localId) return; // Don’t add self
+    if (node.id === this.localId) return;
     try {
       const distance = KBucket.xorDistance(this.localId, node.id);
       const bucketIndex = this.bucketIndex(distance);
@@ -35,12 +34,12 @@ class KBucket {
         if (bucket.length < this.k) {
           bucket.push(node);
         } else {
-          bucket.shift(); // Remove oldest, todo: verify if it actually makes sense
+          bucket.shift();
           bucket.push(node);
         }
       }
     } catch (error) {
-      console.log("ERROR: " + error)
+      console.log("ERROR: " + error);
     }
     console.log("Added node " + node.id + " to the bucket. Buckets:");
     console.log(this.buckets);
@@ -67,7 +66,7 @@ class KBucket {
       node,
       distance: KBucket.xorDistance(node.id, target),
     }));
-    distances.sort((a, b) => a.distance.localeCompare(b.distance)); // Hex string comparison
+    distances.sort((a, b) => a.distance.localeCompare(b.distance));
     return distances.slice(0, k).map((d) => d.node);
   }
 
@@ -76,7 +75,7 @@ class KBucket {
       peerId,
       distance: KBucket.xorDistance(this.localId, peerId),
     }));
-    distances.sort((a, b) => a.distance.localeCompare(b.distance)); // Hex string comparison
+    distances.sort((a, b) => a.distance.localeCompare(b.distance));
     return distances.map((d) => d.peerId);
   }
 
@@ -91,7 +90,7 @@ class KBucket {
         if ((d[i] & (1 << j)) !== 0) return i * 8 + (7 - j);
       }
     }
-    return 0; // Same ID
+    return 0;
   }
 }
 

--- a/contexts/languages/jsons/en.json
+++ b/contexts/languages/jsons/en.json
@@ -174,7 +174,7 @@
             "description_title": "Description"
         },
         "swipe_page": {
-            "searching_otters": "🦦 Otter searching otters for you 🦦"
+            "searching_otters": "🦦 Otter is searching otters for you 🦦"
         }
     },
 

--- a/contexts/signaling.ts
+++ b/contexts/signaling.ts
@@ -26,7 +26,7 @@ const MAX_CANDIDATES_PER_PEER = 30;
 
 const cleanOldCandidates = () => {
   const now = Date.now();
-  const maxAge = 5 * 1000; // 5 seconds
+  const maxAge = 30 * 1000; // 5 seconds
 
   for (const [peerId, queue] of iceCandidateQueue) {
     const filteredQueue = queue.filter(
@@ -71,14 +71,13 @@ export const handleWebRTCSignaling = async (
     channel: RTCDataChannel | null,
     useDHTForSignaling: boolean
   ) => RTCPeerConnection,
-  connectionManager: ConnectionManager,
+  connectionManager: React.MutableRefObject<ConnectionManager | null>,
   setPeers: React.Dispatch<React.SetStateAction<Peer[]>>,
   socket: Socket | null,
   blockedPeersRef: React.MutableRefObject<Set<string>>,
   dht: DHT | null = null,
   signalingChannel?: RTCDataChannel | null
 ) => {
-  console.log([...blockedPeersRef.current])
   if (blockedPeersRef.current.has(message.from)) {
     return;
   }
@@ -86,9 +85,9 @@ export const handleWebRTCSignaling = async (
   try {
     if ('encryptedOffer' in message) {
       if (connections.get(message.from)) {
-        console.log(`Removing peer ${message.from} from connections list - received offer again.`)
+        console.log(`Removing peer ${message.from} from connections list - received offer again.`);
         connections.get(message.from)?.close();
-        connections.delete(message.from); // reconnecting
+        connections.delete(message.from);
       }
       console.log('Handling offer');
       console.log(`WebSocket: ${socket?.connected || false}`);
@@ -124,7 +123,6 @@ export const handleWebRTCSignaling = async (
       }
     } else if ('encryptedAnswer' in message) {
       console.log('Handling answer');
-      console.log(connections);
       const peerId = message.from;
       const peerConnection = connections.get(peerId);
       if (peerConnection) {
@@ -156,9 +154,8 @@ export const handleWebRTCSignaling = async (
         console.warn(`No peer connection found for peer: ${peerId}`);
       }
     } else if ('candidate' in message) {
-      const peerId = message.from;
       cleanOldCandidates();
-
+      const peerId = message.from;
       const peerConnection = connections.get(peerId);
       if (peerConnection) {
         console.log('Handling ICE candidate:', message.candidate);
@@ -202,7 +199,7 @@ export const receiveSignalingMessageOnDHT = (
   dht: DHT,
   profile: Profile,
   connections: Map<string, RTCPeerConnection>,
-  connectionManager: ConnectionManager,
+  connectionManager: React.MutableRefObject<ConnectionManager | null>,
   createPeerConnection: (
     targetPeer: PeerDTO,
     channel: RTCDataChannel | null,
@@ -216,8 +213,8 @@ export const receiveSignalingMessageOnDHT = (
     console.log("In signaling.ts - signalingMessage was emmited");
     console.log("Recieved signalingMessage on DHT");
     handleSignalingOverDataChannels(message, profile, connections, createPeerConnection, setPeers, signalingDataChannels, connectionManager, blockedPeersRef, null, dht);
-  })
-}
+  });
+};
 
 export const handleSignalingOverDataChannels = (
   message: WebSocketMessage,
@@ -230,7 +227,7 @@ export const handleSignalingOverDataChannels = (
   ) => RTCPeerConnection,
   setPeers: React.Dispatch<React.SetStateAction<Peer[]>>,
   signalingDataChannels: Map<string, RTCDataChannel>,
-  connectionManager: ConnectionManager,
+  connectionManager: React.MutableRefObject<ConnectionManager | null>,
   blockedPeersRef: React.MutableRefObject<Set<string>>,
   signalingDataChannel: RTCDataChannel | null,
   dht: DHT | null = null,
@@ -277,7 +274,7 @@ export const handleOffer = async (
   senderPeerId: string,
   target: Profile,
   publicKey: string,
-  connectionManager: ConnectionManager,
+  connectionManager: React.MutableRefObject<ConnectionManager | null>,
   createPeerConnection: (
     targetPeer: PeerDTO,
     channel: RTCDataChannel | null,
@@ -289,15 +286,15 @@ export const handleOffer = async (
   dht: DHT | null = null,
 ) => {
   await verifyPublicKey(senderPeerId, publicKey);
-  const decryptedOffer = await verifyAndDecryptOffer(message, publicKey)
+  const decryptedOffer = await verifyAndDecryptOffer(message, publicKey);
   const senderPeer: PeerDTO = {
     peerId: senderPeerId,
     publicKey: publicKey
-  }
+  };
   const peerConnection = createPeerConnection(senderPeer, signalingChannel, dht ? true : false);
-  connectionManager.triggerFilteringAndPeerDTOFetch(senderPeer.peerId);
+  console.log(connectionManager.current);
+  connectionManager.current!.triggerFilteringAndPeerDTOFetch(senderPeer.peerId);
   console.log(`Peer connection created ${target.peerId}`);
-  // console.log(decryptedOffer);
   await peerConnection.setRemoteDescription(decryptedOffer);
   const answer = await peerConnection.createAnswer();
   await peerConnection.setLocalDescription(answer);
@@ -317,33 +314,30 @@ export const sendEncryptedSDP = async (sender: Profile, targetPeer: PeerDTO, sdp
   let signalingMessage: WebSocketMessage;
   try {
     if (sdp.type == "offer") {
-    verifyPublicKey(targetPeer.peerId, targetPeer.publicKey);
-    signalingMessage = await encryptAndSignOffer(sender.peerId, targetPeer.peerId, sdp, targetPeer.publicKey, sender.publicKey);
-  } else if (sdp.type == "answer") {
-    signalingMessage = await encryptAnswer(sender.peerId, targetPeer.peerId, sdp, sender.publicKey);
-  } else {
-    throw Error(`Unsupported SDP type: ${sdp.type}`)
-  }
-  if (dht) {
-    dht.sendSignalingMessage(signalingMessage.target, signalingMessage);
-  } else if (!signalingChannel) {
-    socket?.emit('messageOne', signalingMessage);
-  } else {
-    signalingChannel.send(JSON.stringify(signalingMessage));
-  }
-  } catch(err) {
+      verifyPublicKey(targetPeer.peerId, targetPeer.publicKey);
+      signalingMessage = await encryptAndSignOffer(sender.peerId, targetPeer.peerId, sdp, targetPeer.publicKey, sender.publicKey);
+    } else if (sdp.type == "answer") {
+      signalingMessage = await encryptAnswer(sender.peerId, targetPeer.peerId, sdp, sender.publicKey);
+    } else {
+      throw Error(`Unsupported SDP type: ${sdp.type}`);
+    }
+    if (dht) {
+      dht.sendSignalingMessage(signalingMessage.target, signalingMessage);
+    } else if (!signalingChannel) {
+      socket?.emit('messageOne', signalingMessage);
+    } else {
+      signalingChannel.send(JSON.stringify(signalingMessage));
+    }
+  } catch (err) {
     console.error(err);
   }
-  
-}
+};
 
 const decryptAnswer = async (encryptedRTCSessionDescription: AnswerMessage): Promise<RTCSessionDescription> => {
   let aesKey: string;
   let iv: string;
-  // console.log(`Handling answer from ${encryptedRTCSessionDescription.from}`)
   const senderUser = await fetchUserFromDB(encryptedRTCSessionDescription.from);
   if (senderUser && senderUser.aesKey && senderUser.iv) {
-    // console.log(senderUser.aesKey)
     aesKey = senderUser.aesKey;
     iv = senderUser.iv;
   } else {
@@ -375,9 +369,9 @@ const encryptAnswer = async (senderId: string, targetId: string, sessionDescript
     encryptedAnswer: encryptedMessage,
     authTag,
     public_key: senderPublicKey
-  }
+  };
   return answer;
-}
+};
 
 export const encryptAndSignOffer = async (
   senderId: string,
@@ -398,7 +392,6 @@ export const encryptAndSignOffer = async (
 
       await createOrUpdateUserWithAESKey(targetUser, targetId, aesKey, iv, keyId, targetPublicKey);
     } else {
-      // console.log(`User ${targetId} found in the db. AES key: ${targetUser.aesKey}, iv: ${targetUser.iv}, keyId: ${targetUser.keyId}`);
       aesKey = targetUser.aesKey;
       iv = targetUser.iv;
       keyId = targetUser.keyId;
@@ -408,11 +401,7 @@ export const encryptAndSignOffer = async (
     const sdp = sessionDescription.sdp;
     var { encryptedMessage, authTag } = encodeAndEncryptMessage(sdp, aesKey, iv);
 
-    // console.log("Offer encrypted");
-    // console.log(encryptedMessage);
     const encryptedAesKey = encryptAesKey(targetPublicKey, aesKey);
-    // console.log("AES key encrpyted")
-    // console.log(encryptedAesKey)
     const encryptedAesKeySignature = await signMessage(encryptedAesKey);
 
     const payload: OfferMessage = {
@@ -445,11 +434,8 @@ export const verifyAndDecryptOffer = async (
     const senderUser = await fetchUserFromDB(from);
     console.log(senderUser?.keyId);
     if (senderUser && senderUser.keyId && senderUser.keyId === keyId && senderUser.aesKey && senderUser.iv) {
-      // console.log(`Key ID matches for user ${from}. Using stored AES key: ${senderUser.aesKey}`);
       aesKey = senderUser.aesKey;
     } else {
-      // console.log(`Key ID mismatch or no key for user ${from}. Decrypting AES key.`);
-
       verifySignature(encryptedAesKey, senderPublicKey, encryptedAesKeySignature);
       aesKey = await decryptAESKey(encryptedAesKey, encryptedAesKey);
 
@@ -457,7 +443,6 @@ export const verifyAndDecryptOffer = async (
     }
 
     const decodedOffer = decryptAndDecodeMessage(aesKey, iv, authTag, encryptedOffer);
-    // console.log('Decrypted SDP:', decodedOffer);
     return new RTCSessionDescription({ sdp: decodedOffer, type: 'offer' });
   } catch (err) {
     console.error('Verification/Decryption failed:', err);
@@ -468,7 +453,6 @@ export const verifyAndDecryptOffer = async (
 async function createOrUpdateUserWithAESKey(targetUser: User | null, targetId: string, aesKey: string, iv: string, keyId: string, targetPublicKey: string) {
   if (targetUser) {
     await updateUser(targetId, { aesKey, iv, keyId });
-    // console.log(`User ${targetId} updated with keyId ${keyId}`);
   } else {
     await saveUserToDB({
       peerId: targetId,
@@ -478,7 +462,6 @@ async function createOrUpdateUserWithAESKey(targetUser: User | null, targetId: s
       iv,
       keyId,
     });
-    // console.log(`User ${targetId} added to db with keyId ${keyId}`);
   }
 }
 
@@ -514,7 +497,6 @@ async function decryptAESKey(aesKey: string, encryptedAesKey: string) {
 }
 
 const verifyPublicKey = async (peerId: string, publicKey: string): Promise<void> => {
-  // console.log(`Verifying peerId for ${peerId}`);
   const user = await fetchUserFromDB(peerId);
   if (user && user.publicKey) {
     return;
@@ -523,7 +505,7 @@ const verifyPublicKey = async (peerId: string, publicKey: string): Promise<void>
   } else {
     throw Error("Public key hash doesn't match peerId value.");
   }
-}
+};
 
 const createSHA1Hash = (inputString: string): string => {
   const hash = crypto.createHash('SHA-1')

--- a/contexts/signaling.ts
+++ b/contexts/signaling.ts
@@ -232,7 +232,7 @@ export const handleSignalingOverDataChannels = (
   signalingDataChannel: RTCDataChannel | null,
   dht: DHT | null = null,
 ): void => {
-  if (message.target === profile.peerId) {
+  if (message.target === selfProfile.peerId) {
     console.log(
       "Signaling over datachannels reached its destination. Handling request: " +
       JSON.stringify(message)

--- a/contexts/signaling.ts
+++ b/contexts/signaling.ts
@@ -218,7 +218,7 @@ export const receiveSignalingMessageOnDHT = (
 
 export const handleSignalingOverDataChannels = (
   message: WebSocketMessage,
-  profile: Profile,
+  selfProfile: Profile,
   connections: Map<string, RTCPeerConnection>,
   createPeerConnection: (
     targetPeer: PeerDTO,
@@ -240,7 +240,7 @@ export const handleSignalingOverDataChannels = (
     handleWebRTCSignaling(
       message,
       connections,
-      profile,
+      selfProfile,
       createPeerConnection,
       connectionManager,
       setPeers,

--- a/contexts/socket.ts
+++ b/contexts/socket.ts
@@ -23,7 +23,7 @@ export const handleWebSocketMessages = (
   socketRef: Socket,
   profile: Profile,
   connections: Map<string, RTCPeerConnection>,
-  connectionManager: ConnectionManager,
+  connectionManager: React.MutableRefObject<ConnectionManager | null>,
   blockedPeersRef: React.MutableRefObject<Set<string>>,
   createPeerConnection: (
     targetPeer: PeerDTO,
@@ -39,7 +39,7 @@ export const handleWebSocketMessages = (
         console.log("Connections");
         console.log(connectionsPayload);
 
-        connectionManager.handleNewPeers(connectionsPayload, null);
+        connectionManager.current!.handleNewPeers(connectionsPayload, null);
       } else {
         handleWebRTCSignaling(
           message,


### PR DESCRIPTION
# Changelog
### Added

- **Connection Limiting**: Implemented a connection limiting mechanism to manage the number of active peer connections, triggered every 5 seconds and when adding new peers. The mechanism ensures room for new peers by:
  - First removing peers that are not in `profilesToDisplay`, `filteredPeersReadyToDisplay`, or the DHT.
  - If no such peers are available, disconnecting peers that have already been displayed (based on the `currentIndex` value).
  - As a last resort, removing peers that are furthest from the local node in the DHT.
  - Peers in `profilesToDisplay` that weren't displated are protected and never removed.

### Fixed

- **ICE Candidates Handling**: Added an ICE candidates queue on the offerer side to optimize signaling. ICE candidates are now shared only after receiving the answer, reducing the number of messages sent through DHT signaling when the target peer is offline.
- **State Sharing and Variable Passing**: Resolved minor issues with state sharing and variable passing to improve reliability and consistency in the ConnectionManager.